### PR TITLE
Sign apt's Release file with multiple GPG keys

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -6,7 +6,7 @@
 
 #/ Usage: freight cache [-k] [-g <email>] [-p <passphrase-file>] [-c <conf>] [-v] [-h] [<manager>/<distro>][...]
 #/   -k, --keep                          keep unreferenced versions of packages
-#/   -g <email>, --gpg=<email>           GPG key to use
+#/   -g <email>, --gpg=<email>           GPG key to use, may be given multiple times
 #/   -p <passphrase file>, 
 #/   --passphrase-file=<passphrase-file> path to file containing the passphrase of the GPG key
 #/   -c <conf>, --conf=<conf>            config file to parse
@@ -23,9 +23,18 @@ while [ "$#" -gt 0 ]
 do
 	case "$1" in
 		-k|--keep) KEEP=1 shift;;
-		-g|--gpg) GPG="$2" shift 2;;
-		-g*) GPG="$(echo "$1" | cut -c"3-")" shift;;
-		--gpg=*) GPG="$(echo "$1" | cut -c"7-")" shift;;
+		-g|--gpg)
+			[ -z "$GPG" ] && GPG=()
+			GPG+=("$2")
+			shift 2;;
+		-g*)
+			[ -z "$GPG" ] && GPG=()
+			GPG+=("$(echo "$1" | cut -c"3-")")
+			shift;;
+		--gpg=*)
+			[ -z "$GPG" ] && GPG=()
+			GPG+=("$(echo "$1" | cut -c"7-")")
+			shift;;
 		-p|--passphrase-file) GPG_PASSPHRASE_FILE="$2" shift 2;;
 		-p*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"3-")" shift;;
 		--passphrase-file=*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"19-")" shift;;

--- a/bin/freight-init
+++ b/bin/freight-init
@@ -17,6 +17,7 @@
 set -e
 
 CONF="etc/freight.conf"
+GPG=()
 
 usage() {
     grep "^#/" "$0" | cut -c"4-" >&2
@@ -25,9 +26,15 @@ usage() {
 while [ "$#" -gt 0 ]
 do
 	case "$1" in
-		-g|--gpg) GPG="$2" shift 2;;
-		-g*) GPG="$(echo "$1" | cut -c"3-")" shift;;
-		--gpg=*) GPG="$(echo "$1" | cut -c"7-")" shift;;
+		-g|--gpg)
+			GPG+=("$2")
+			shift 2;;
+		-g*)
+			GPG+=("$(echo "$1" | cut -c"3-")")
+			shift;;
+		--gpg=*)
+			GPG+=("$(echo "$1" | cut -c"7-")")
+			shift;;
 		-c|--conf) CONF="$2" shift 2;;
 		-c*) CONF="$(echo "$1" | cut -c"3-")" shift;;
 		--conf=*) CONF="$(echo "$1" | cut -c"8-")" shift;;
@@ -50,7 +57,7 @@ do
 	esac
 done
 DIRNAME="$(cd "${1:-"."}" && pwd)"
-[ -z "$GPG" -o -z "$DIRNAME" ] && usage 1
+[ ${#GPG[@]} -eq 0 -o -z "$DIRNAME" ] && usage 1
 
 # The default value for VARLIB and VARCACHE lies within DIRNAME but otherwise
 # follows the FHS style.
@@ -67,7 +74,7 @@ mkdir -p "$(dirname "$CONF")"
 cat >"$CONF" <<EOF
 VARLIB="$VARLIB"
 VARCACHE="$VARCACHE"
-GPG="$GPG"
+GPG=(${GPG[*]})
 EOF
 [ "$ARCHS" ] && echo "ARCHS=\"$ARCHS\"" >>"$CONF"
 [ "$ORIGIN" ] && echo "ORIGIN=\"$ORIGIN\"" >>"$CONF"

--- a/etc/freight.conf.example
+++ b/etc/freight.conf.example
@@ -13,10 +13,14 @@ LABEL="Freight"
 # time (off).
 CACHE="off"
 
-# GPG key to use to sign repositories.  This is required by the `apt`
+# GPG key(s) to use to sign repositories.  This is required by the `apt`
 # repository provider.  Use `gpg --gen-key` (see `gpg`(1) for more
 # details) to generate a key and put its email address here.
+#
+# Multiple addresses can be given in an array to sign the repository with
+# them all.
 GPG="example@example.com"
+# GPG=("example@example.com" "another@example.com")
 
 # Whether to follow symbolic links in `$VARLIB` to produce extra components
 # in the cache directory (on) or not (off).

--- a/man/man1/freight-cache.1
+++ b/man/man1/freight-cache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FREIGHT\-CACHE" "1" "January 2014" "" "Freight"
+.TH "FREIGHT\-CACHE" "1" "February 2016" "" "Freight"
 .
 .SH "NAME"
 \fBfreight\-cache\fR \- (re)builds package repositories
@@ -29,7 +29,7 @@ Keep unreferenced versions of packages\. This is different than keeping multiple
 .
 .TP
 \fB\-g\fR \fIemail\fR, \fB\-\-gpg=\fR\fIemail\fR
-Use an alternate GPG key\.
+Use an alternate GPG key\. May be given multiple times\.
 .
 .TP
 \fB\-p\fR \fIpassphrase file\fR, \fB\-\-passphrase\-file=\fR\fIpassphrase file\fR

--- a/man/man1/freight-cache.1.ronn
+++ b/man/man1/freight-cache.1.ronn
@@ -20,7 +20,7 @@ From version 0.0.8 onwards, distros in an APT repository no longer share the con
 * `-k`, `--keep`:
   Keep unreferenced versions of packages.  This is different than keeping multiple versions of a package in the repository, which is supported without any special options.
 * `-g` _email_, `--gpg=`_email_:
-  Use an alternate GPG key.
+  Use an alternate GPG key. May be given multiple times.
 * `-p` _passphrase file_, `--passphrase-file=`_passphrase file_:
   Use an alternate file containing the GPG key passphrase. This file should obviously be protected and only readable by the user running Freight.
 * `-c` _conf_, `--conf=`_conf_:

--- a/man/man1/freight-init.1
+++ b/man/man1/freight-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FREIGHT\-INIT" "1" "January 2014" "" "Freight"
+.TH "FREIGHT\-INIT" "1" "February 2016" "" "Freight"
 .
 .SH "NAME"
 \fBfreight\-init\fR \- initialize a Freight directory
@@ -22,7 +22,7 @@ Configuration is stored in \fB_dirname_/\.freight\.conf\fR\.
 .
 .TP
 \fB\-g\fR \fIgpg\fR, \fB\-\-gpg=\fR\fIgpg\fR`
-GPG key\.
+GPG key\. May be given multiple times\.
 .
 .TP
 \fB\-l\fR \fIvarlib\fR, \fB\-\-varlib=\fR\fIvarlib\fB_\fR\fR

--- a/man/man1/freight-init.1.ronn
+++ b/man/man1/freight-init.1.ronn
@@ -16,7 +16,7 @@ Configuration is stored in `_dirname_/.freight.conf`.
 ## OPTIONS
 
 * `-g` _gpg_, `--gpg=`_gpg_`:
-  GPG key.
+  GPG key.  May be given multiple times.
 * `-l` _varlib_, `--varlib=`_varlib`_:
   VARLIB directory to use.  Defaults to `_dirname_/lib`
 * `--varcache=`_varcache`_:

--- a/man/man5/freight.5
+++ b/man/man5/freight.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FREIGHT" "5" "January 2014" "" "Freight"
+.TH "FREIGHT" "5" "February 2016" "" "Freight"
 .
 .SH "NAME"
 \fBfreight\fR \- Freight configuration
@@ -37,7 +37,7 @@ The \fBLabel\fR field in the Debian archive\.
 .
 .TP
 \fBGPG\fR
-The GPG key to use\. This value must be set either in a configuration file or by using the \fB\-g\fR option to \fBfreight\-cache\fR(1)\.
+The GPG key(s) to use\. This value must be set either in a configuration file or by using the \fB\-g\fR option to \fBfreight\-cache\fR(1)\. Multiple keys can be given to sign the repository with more signatures\.
 .
 .TP
 \fBGPG_PASSPHRASE_FILE\fR

--- a/man/man5/freight.5.ronn
+++ b/man/man5/freight.5.ronn
@@ -20,7 +20,7 @@ The Freight configuration is a `source`d shell script that defines a few importa
 * `CACHE`:
   _on_ to cache package control files or _off_ to read them from the packages on each `freight-cache`(1) run.
 * `GPG`:
-  The GPG key to use.  This value must be set either in a configuration file or by using the `-g` option to `freight-cache`(1).
+  The GPG key(s) to use.  This value must be set either in a configuration file or by using the `-g` option to `freight-cache`(1).  Multiple keys can be given to sign the repository with more signatures.
 * `GPG_PASSPHRASE_FILE`:
   Pathname of a file containing the GPGP private key's passphrase.  This sets the `--passphrase-fd` and `--passphrase-file` options to `gpg`(1).  The passphrase file can be set either in a configuration file or by using the `-p` option to `freight-cache`(1).
 * `SYMLINKS`:


### PR DESCRIPTION
The GPG config option and associated command arguments now accept
multiple GPG keys, which are all used to sign the Release file.  This
makes it easier to roll keys, similar to the Debian archives which are
signed with multiple release keys.