### PR TITLE
Change freight-cache and init to use bash

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Rebuild the Freight cache from the Freight library.  The cache contains
 # actual repositories that are suitable targets for `apt-get` (and maybe
@@ -22,7 +22,7 @@ usage() {
 while [ "$#" -gt 0 ]
 do
 	case "$1" in
-		-k|--keep) KEEP=1 shift;;
+		-k|--keep) KEEP=1; shift;;
 		-g|--gpg)
 			[ -z "$GPG" ] && GPG=()
 			GPG+=("$2")
@@ -35,13 +35,13 @@ do
 			[ -z "$GPG" ] && GPG=()
 			GPG+=("$(echo "$1" | cut -c"7-")")
 			shift;;
-		-p|--passphrase-file) GPG_PASSPHRASE_FILE="$2" shift 2;;
-		-p*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"3-")" shift;;
-		--passphrase-file=*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"19-")" shift;;
-		-c|--conf) CONF="$2" shift 2;;
-		-c*) CONF="$(echo "$1" | cut -c"3-")" shift;;
-		--conf=*) CONF="$(echo "$1" | cut -c"8-")" shift;;
-		-v|--verbose) VERBOSE=1 shift;;
+		-p|--passphrase-file) GPG_PASSPHRASE_FILE="$2"; shift 2;;
+		-p*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"3-")"; shift;;
+		--passphrase-file=*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"19-")"; shift;;
+		-c|--conf) CONF="$2"; shift 2;;
+		-c*) CONF="$(echo "$1" | cut -c"3-")"; shift;;
+		--conf=*) CONF="$(echo "$1" | cut -c"8-")"; shift;;
+		-v|--verbose) VERBOSE=1; shift;;
 		-h|--help) usage 0;;
 		-*) echo "# [freight] unknown switch: $1" >&2;;
 		*) break;;

--- a/bin/freight-clear-cache
+++ b/bin/freight-clear-cache
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Clear the cache that is built up during freight-cache runs
 # so that it can be regenerated on the next freight-cache invocation.
@@ -17,10 +17,10 @@ usage() {
 while [ "$#" -gt 0 ]
 do
 	case "$1" in
-		-c|--conf) CONF="$2" shift 2;;
-		-c*) CONF="$(echo "$1" | cut -c"3-")" shift;;
-		--conf=*) CONF="$(echo "$1" | cut -c"8-")" shift;;
-		-v|--verbose) VERBOSE=1 shift;;
+		-c|--conf) CONF="$2"; shift 2;;
+		-c*) CONF="$(echo "$1" | cut -c"3-")"; shift;;
+		--conf=*) CONF="$(echo "$1" | cut -c"8-")"; shift;;
+		-v|--verbose) VERBOSE=1; shift;;
 		-h|--help) usage 0;;
 		-*) echo "# [freight] unknown switch: $1" >&2;;
 		*) break;;

--- a/bin/freight-init
+++ b/bin/freight-init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Initialize a Freight directory (similar to git init).
 
@@ -35,22 +35,22 @@ do
 		--gpg=*)
 			GPG+=("$(echo "$1" | cut -c"7-")")
 			shift;;
-		-c|--conf) CONF="$2" shift 2;;
-		-c*) CONF="$(echo "$1" | cut -c"3-")" shift;;
-		--conf=*) CONF="$(echo "$1" | cut -c"8-")" shift;;
-		--libdir) VARLIB="$2" shift 2;;
-		--libdir=*) VARLIB="$(echo "$1" | cut -c"10-")" shift;;
-		--cachedir) VARCACHE="$2" shift 2;;
-		--cachedir=*) VARCACHE="$(echo "$1" | cut -c"12-")" shift;;
-		--archs) ARCHS="$2" shift 2;;
-		--archs=*) ARCHS="$(echo "$1" | cut -c"9-")" shift;;
-		--origin) ORIGIN="$2" shift 2;;
-		--origin=*) ORIGIN="$(echo "$1" | cut -c"10-")" shift;;
-		--label) LABEL="$2" shift 2;;
-		--label=*) LABEL="$(echo "$1" | cut -c"9-")" shift;;
-		--suite) SUITE="$2" shift 2;;
-		--suite=*) SUITE="$(echo "$1" | cut -c"9-")" shift;;
-		-v|--verbose) VERBOSE=1 shift;;
+		-c|--conf) CONF="$2"; shift 2;;
+		-c*) CONF="$(echo "$1" | cut -c"3-")"; shift;;
+		--conf=*) CONF="$(echo "$1" | cut -c"8-")"; shift;;
+		--libdir) VARLIB="$2"; shift 2;;
+		--libdir=*) VARLIB="$(echo "$1" | cut -c"10-")"; shift;;
+		--cachedir) VARCACHE="$2"; shift 2;;
+		--cachedir=*) VARCACHE="$(echo "$1" | cut -c"12-")"; shift;;
+		--archs) ARCHS="$2"; shift 2;;
+		--archs=*) ARCHS="$(echo "$1" | cut -c"9-")"; shift;;
+		--origin) ORIGIN="$2"; shift 2;;
+		--origin=*) ORIGIN="$(echo "$1" | cut -c"10-")"; shift;;
+		--label) LABEL="$2"; shift 2;;
+		--label=*) LABEL="$(echo "$1" | cut -c"9-")"; shift;;
+		--suite) SUITE="$2"; shift 2;;
+		--suite=*) SUITE="$(echo "$1" | cut -c"9-")"; shift;;
+		-v|--verbose) VERBOSE=1; shift;;
 		-h|--help) usage 0;;
 		-*) echo "# [freight] unknown switch: $1" >&2;;
 		*) break;;


### PR DESCRIPTION
Permits use of bash arrays in the multiple GPG support.

Fixes #8 

---

The oddity with the semicolons in the case statement is that without them, bash seems to create subshells preventing the variables from taking effect.

Caught by the tests in #9 :smile: 

