### PR TITLE
Replace bash-only GPG UID array with string

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -24,16 +24,25 @@ do
 	case "$1" in
 		-k|--keep) KEEP=1 shift;;
 		-g|--gpg)
-			[ -z "$GPG" ] && GPG=()
-			GPG+=("$2")
+			if [ -z "$GPG" ]; then
+				GPG=$2
+			else
+				GPG="$GPG $2"
+			fi
 			shift 2;;
 		-g*)
-			[ -z "$GPG" ] && GPG=()
-			GPG+=("$(echo "$1" | cut -c"3-")")
+			if [ -z "$GPG" ]; then
+				GPG=$(echo "$1" | cut -c"3-")
+			else
+				GPG="$GPG $(echo "$1" | cut -c"3-")"
+			fi
 			shift;;
 		--gpg=*)
-			[ -z "$GPG" ] && GPG=()
-			GPG+=("$(echo "$1" | cut -c"7-")")
+			if [ -z "$GPG" ]; then
+				GPG=$(echo "$1" | cut -c"7-")
+			else
+				GPG="$GPG $(echo "$1" | cut -c"7-")"
+			fi
 			shift;;
 		-p|--passphrase-file) GPG_PASSPHRASE_FILE="$2" shift 2;;
 		-p*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"3-")" shift;;

--- a/bin/freight-init
+++ b/bin/freight-init
@@ -17,7 +17,7 @@
 set -e
 
 CONF="etc/freight.conf"
-GPG=()
+GPG=""
 
 usage() {
     grep "^#/" "$0" | cut -c"4-" >&2
@@ -27,13 +27,25 @@ while [ "$#" -gt 0 ]
 do
 	case "$1" in
 		-g|--gpg)
-			GPG+=("$2")
+			if [ -z "$GPG" ]; then
+				GPG=$2
+			else
+				GPG="$GPG $2"
+			fi
 			shift 2;;
 		-g*)
-			GPG+=("$(echo "$1" | cut -c"3-")")
+			if [ -z "$GPG" ]; then
+				GPG=$(echo "$1" | cut -c"3-")
+			else
+				GPG="$GPG $(echo "$1" | cut -c"3-")"
+			fi
 			shift;;
 		--gpg=*)
-			GPG+=("$(echo "$1" | cut -c"7-")")
+			if [ -z "$GPG" ]; then
+				GPG=$(echo "$1" | cut -c"7-")
+			else
+				GPG="$GPG $(echo "$1" | cut -c"7-")"
+			fi
 			shift;;
 		-c|--conf) CONF="$2" shift 2;;
 		-c*) CONF="$(echo "$1" | cut -c"3-")" shift;;
@@ -57,7 +69,7 @@ do
 	esac
 done
 DIRNAME="$(cd "${1:-"."}" && pwd)"
-[ ${#GPG[@]} -eq 0 -o -z "$DIRNAME" ] && usage 1
+[ -z "$GPG" -o -z "$DIRNAME" ] && usage 1
 
 # The default value for VARLIB and VARCACHE lies within DIRNAME but otherwise
 # follows the FHS style.
@@ -74,7 +86,7 @@ mkdir -p "$(dirname "$CONF")"
 cat >"$CONF" <<EOF
 VARLIB="$VARLIB"
 VARCACHE="$VARCACHE"
-GPG=(${GPG[*]})
+GPG="$GPG"
 EOF
 [ "$ARCHS" ] && echo "ARCHS=\"$ARCHS\"" >>"$CONF"
 [ "$ORIGIN" ] && echo "ORIGIN=\"$ORIGIN\"" >>"$CONF"

--- a/etc/freight.conf.example
+++ b/etc/freight.conf.example
@@ -17,10 +17,9 @@ CACHE="off"
 # repository provider.  Use `gpg --gen-key` (see `gpg`(1) for more
 # details) to generate a key and put its email address here.
 #
-# Multiple addresses can be given in an array to sign the repository with
-# them all.
+# Multiple addresses can be given sign the repository with them all.
 GPG="example@example.com"
-# GPG=("example@example.com" "another@example.com")
+# GPG="example@example.com another@example.com"
 
 # Whether to follow symbolic links in `$VARLIB` to produce extra components
 # in the cache directory (on) or not (off).

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -191,7 +191,7 @@ EOF
 
 	# Sign the top-level `Release` file with `gpg`, for each key and
 	# concatenate signatures.
-	for GPGKEY in ${GPG[@]}; do
+	for GPGKEY in $GPG; do
 		gpg -abs$([ "$TTY" ] || echo " --no-tty") --use-agent -u"$GPGKEY" \
 			$([ "$GPG_PASSPHRASE_FILE" ] && echo " --batch --passphrase-fd 1 --passphrase-file $GPG_PASSPHRASE_FILE") \
 			-o"$TMP/release_last_signature.gpg" "$DISTCACHE/Release" || {
@@ -212,7 +212,7 @@ EOF
 	# the appropriate public keys.  `keyring.gpg` is appropriate for
 	# copying directly to `/etc/apt/trusted.gpg.d`.
 	mkdir -m700 -p "$TMP/gpg"
-	gpg -q --export -a ${GPG[*]} |
+	gpg -q --export -a $GPG |
 	tee "$VARCACHE/pubkey.gpg" |
 	gpg -q --homedir "$TMP/gpg" --import
 	chmod 644 "$TMP/gpg/pubring.gpg"


### PR DESCRIPTION
Using a space-separated string of GPG UIDs is compatible with non-bash,
POSIX compatible shells such as dash.

Fixes #8