### PR TITLE
Fixed warnings about not removable non-empty folders in apt_clean()

### DIFF
--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -460,5 +460,6 @@ apt_cache_source() {
 
 # Clean up old packages in the pool.
 apt_clean() {
-	find "$VARCACHE/pool" -links 1 -delete || true
+	find "$VARCACHE/pool" -links 1 -type f -delete
+	find "$VARCACHE/pool" -type d -empty -delete
 }


### PR DESCRIPTION
freight-cache produces multiple lines warnings (proportional to the size of cache):
`find: cannot delete [...]/cache/pool/[...]: Directory not empty`

The behavior is correct. This directories should only be removed, when they are empty after removing old packages. Thus the warnings are erroneous. 