### PR TITLE
Add ability to configure digest algorithm used to sign repository.

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -4,11 +4,13 @@
 # actual repositories that are suitable targets for `apt-get` (and maybe
 # more in the future).
 
-#/ Usage: freight cache [-k] [-g <email>] [-p <passphrase-file>] [-c <conf>] [-v] [-h] [<manager>/<distro>][...]
+#/ Usage: freight cache [-k] [-g <email>] [-p <passphrase-file>] [-a <digest-algorithm>] [-c <conf>] [-v] [-h] [<manager>/<distro>][...]
 #/   -k, --keep                          keep unreferenced versions of packages
 #/   -g <email>, --gpg=<email>           GPG key to use, may be given multiple times
 #/   -p <passphrase file>, 
 #/   --passphrase-file=<passphrase-file> path to file containing the passphrase of the GPG key
+#/   -a <digest algorithm>,
+#/   --digest-algo=<digest-algorithm>    digest algorithm that GPG should use, e.g SHA512
 #/   -c <conf>, --conf=<conf>            config file to parse
 #/   -v, --verbose                       verbose mode
 #/   -h, --help                          show this help message
@@ -47,6 +49,9 @@ do
         -p|--passphrase-file) GPG_PASSPHRASE_FILE="$2" shift 2;;
         -p*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"3-")" shift;;
         --passphrase-file=*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"19-")" shift;;
+        -a|--digest-algo) GPG_DIGEST_ALGO="$2" shift 2;;
+        -a*) GPG_DIGEST_ALGO="$(echo "$1" | cut -c"3-")" shift;;
+        --digest-algo=*) GPG_DIGEST_ALGO="$(echo "$1" | cut -c"15-")" shift;;
         -c|--conf) CONF="$2" shift 2;;
         -c*) CONF="$(echo "$1" | cut -c"3-")" shift;;
         --conf=*) CONF="$(echo "$1" | cut -c"8-")" shift;;
@@ -63,6 +68,9 @@ LIB="$(cd "$(dirname "$(dirname "$0")")/lib/freight" && pwd)"
 # If `GPG_PASSPHRASE_FILE` is set the specified file should exist and be
 # readable by the user running Freight.
 [ -z "$GPG_PASSPHRASE_FILE" -o -r "$GPG_PASSPHRASE_FILE" ] || echo "# [freight] could not read passphrase file: $GPG_PASSPHRASE_FILE." >&2
+
+# If `GPG_DIGEST_ALGO` is unset, force it to the freight default of SHA512
+[ -z "$GPG_DIGEST_ALGO" ] && GPG_DIGEST_ALGO="SHA512"
 
 # Create a working directory on the same device as the Freight cache.
 mkdir -p "$VARCACHE"

--- a/etc/freight.conf.example
+++ b/etc/freight.conf.example
@@ -21,6 +21,13 @@ CACHE="off"
 GPG="example@example.com"
 # GPG="example@example.com another@example.com"
 
+# Message digest algorithm that GPG should use to sign the repository.
+# It is not recommended to use SHA1 as new versions of `apt` will report
+# that the repository is half-broken due to weak digest.
+#
+# SHA512 is the default
+GPG_DIGEST_ALGO="SHA512"
+
 # Whether to follow symbolic links in `$VARLIB` to produce extra components
 # in the cache directory (on) or not (off).
 SYMLINKS="off"

--- a/man/man1/freight-cache.1
+++ b/man/man1/freight-cache.1
@@ -36,6 +36,10 @@ Use an alternate GPG key\. May be given multiple times\.
 Use an alternate file containing the GPG key passphrase\. This file should obviously be protected and only readable by the user running Freight\.
 .
 .TP
+\fB\-a\fR \fIdigest algorithm\fR, \fB\-\-digest\-algo=\fR\fIdigest algorithm\fR
+Message digest algorithm that GPG should use to sign the repository, e\.g SHA512
+.
+.TP
 \fB\-c\fR \fIconf\fR, \fB\-\-conf=\fR\fIconf\fR
 Use an alternate configuration file\.
 .

--- a/man/man1/freight-cache.1.ronn
+++ b/man/man1/freight-cache.1.ronn
@@ -23,6 +23,8 @@ From version 0.0.8 onwards, distros in an APT repository no longer share the con
   Use an alternate GPG key. May be given multiple times.
 * `-p` _passphrase file_, `--passphrase-file=`_passphrase file_:
   Use an alternate file containing the GPG key passphrase. This file should obviously be protected and only readable by the user running Freight.
+* `-a` _digest algorithm_, `--digest-algo=`_digest algorithm_:
+  Message digest algorithm that GPG should use to sign the repository, e.g SHA512
 * `-c` _conf_, `--conf=`_conf_:
   Use an alternate configuration file.
 * `-v`, `--verbose`:

--- a/man/man5/freight.5
+++ b/man/man5/freight.5
@@ -44,6 +44,10 @@ The GPG key(s) to use\. This value must be set either in a configuration file or
 Pathname of a file containing the GPGP private key\'s passphrase\. This sets the \fB\-\-passphrase\-fd\fR and \fB\-\-passphrase\-file\fR options to \fBgpg\fR(1)\. The passphrase file can be set either in a configuration file or by using the \fB\-p\fR option to \fBfreight\-cache\fR(1)\.
 .
 .TP
+\fBGPG_DIGEST_ALGO\fR
+Message digest algorithm that GPG should use to sign the repository\. Apt is phasing out SHA1 so it is recommended to use SHA512 for most use\-cases\. This sets the \fB\-\-personal\-digest\-preferences\fR option to \fBgpg\fR(1)\. The digest algorithm can be set either in a configuration file or by using the \fB\-a\fR option to \fBfreight\-cache\fR(1)\.
+.
+.TP
 \fBSYMLINKS\fR
 \fIon\fR to follow symbolic links in \fBVARLIB\fR to produce extra components in the cache directory or \fIoff\fR to offer no special treatment\.
 .

--- a/man/man5/freight.5.ronn
+++ b/man/man5/freight.5.ronn
@@ -23,6 +23,8 @@ The Freight configuration is a `source`d shell script that defines a few importa
   The GPG key(s) to use.  This value must be set either in a configuration file or by using the `-g` option to `freight-cache`(1).  Multiple keys can be given to sign the repository with more signatures.
 * `GPG_PASSPHRASE_FILE`:
   Pathname of a file containing the GPGP private key's passphrase.  This sets the `--passphrase-fd` and `--passphrase-file` options to `gpg`(1).  The passphrase file can be set either in a configuration file or by using the `-p` option to `freight-cache`(1).
+* `GPG_DIGEST_ALGO`:
+  Message digest algorithm that GPG should use to sign the repository. Apt is phasing out SHA1 so it is recommended to use SHA512 for most use-cases.  This sets the `--personal-digest-preferences` option to `gpg`(1).  The digest algorithm can be set either in a configuration file or by using the `-a` option to `freight-cache`(1).
 * `SYMLINKS`:
   _on_ to follow symbolic links in `VARLIB` to produce extra components in the cache directory or _off_ to offer no special treatment.
 


### PR DESCRIPTION
The Apt project have deprecated SHA1 for signing repos and will be removing support for it at the start of next year: https://wiki.debian.org/Teams/Apt/Sha1Removal

From Ubuntu 16.04 onward, a warning message for all repos signed with SHA1 will be displayed when apt-get is run:

  The repository is insufficiently signed by key KEYID (weak digest)

I have added a new configuration element (GPG_DIGEST_ALGO) to freight which adds support for telling GPG that we want to use SHA256 or SHA512. I have left the defaults alone as I'm not sure if there are any side effects to dropping SHA1.

I have also added support for the SHA512 field in Release and Package files generated by Freight.