### PR TITLE
Handle the scenario where $VARLIB is a symlink

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -88,7 +88,7 @@ cd "$VARLIB"
 if [ -z "$*" ]
 then
     DIRS="$(
-        find "$VARLIB" -mindepth 2 -maxdepth 2 -type d -printf "%P\n" |
+        find "$VARLIB"/ -mindepth 2 -maxdepth 2 -type d -printf "%P\n" |
         grep -v "^\\." |
         tr "\n" " "
     )"
@@ -100,7 +100,7 @@ do
 
     # Parse the manager and distro out of the Freight library path.
     DIR="$(readlink -f "$DIR")"
-    DIR="${DIR##"$VARLIB/"}"
+    DIR="${DIR##"$(readlink -f "$VARLIB")/"}"
     MANAGER="$(dirname "$DIR")"
     DIST="$(basename "$DIR")"
 

--- a/test/apt_add.bats
+++ b/test/apt_add.bats
@@ -52,3 +52,10 @@ setup() {
     assert_output "# [freight] added ${FIXTURES}/source_1.0.orig.tar.gz to apt/example"
     test -e ${FREIGHT_LIB}/apt/example/source_1.0.orig.tar.gz
 }
+
+@test "freight-add handles VARLIB being a symlink" {
+    mv $FREIGHT_LIB ${FREIGHT_LIB}_real
+    ln -s ${FREIGHT_LIB}_real $FREIGHT_LIB
+    freight_add ${FIXTURES}/test_1.0_all.deb apt/example/comp
+    test -e ${FREIGHT_LIB}_real/apt/example/comp/test_1.0_all.deb
+}

--- a/test/apt_cache.bats
+++ b/test/apt_cache.bats
@@ -69,3 +69,11 @@ setup() {
     assert_output ""
     test -e ${FREIGHT_CACHE}/pool/example/main/t/test/test_1.0_all.deb
 }
+
+@test "freight-cache handles VARLIB being a symlink" {
+    mv $FREIGHT_LIB ${FREIGHT_LIB}_real
+    ln -s ${FREIGHT_LIB}_real $FREIGHT_LIB
+    freight_cache
+    test -e ${FREIGHT_CACHE}/pool/example/comp/t/test/test_1.0_all.deb
+    test -e ${FREIGHT_CACHE}/pool/example/main/t/test/test_1.0_all.deb
+}


### PR DESCRIPTION
Resubmitted from https://github.com/rcrowley/freight/pull/68, with extra tests and another trivial fix that was required to make them pass (when VARLIB has no trailing /).