### PR TITLE
Refresh freight-init man page

### DIFF
--- a/man/man1/freight-init.1
+++ b/man/man1/freight-init.1
@@ -7,30 +7,46 @@
 \fBfreight\-init\fR \- initialize a Freight directory
 .
 .SH "SYNOPSIS"
-\fBfreight init\fR [\fB\-l\fR \fIvarlib\fR] [\fB\-\-cache\fR \fIvarcache\fR] \fB\-g\fR \fIgpg\fR \fIdirname\fR
+\fBfreight init\fR [\fB\-\-libdir\fR \fIvarlib\fR] [\fB\-\-cachedir\fR \fIvarcache\fR] [\fB\-\-archs\fR \fIarchs\fR] [\fB\-\-origin\fR \fIorigin\fR] [\fB\-\-label\fR \fIlabel\fR] [\fB\-v\fR] [\fB\-h\fR] \fB\-g\fR \fIgpg\fR \fIdirname\fR
 .
 .SH "DESCRIPTION"
-\fBfreight\-init\fR will setup a directory to be used by Freight\. It will generate small wrappers around the original Freight commands\. Use \fB\./freight\-add\fR and \fB\./freight\-cache\fR to work against the \fBVARLIB\fR and \fBVARCACHE\fR given to \fBfreight init\fR\.
+\fBfreight\-init\fR will setup a directory to be used by Freight\. It will generate small wrappers around the original Freight commands\. Use \fBfreight\-add\fR(1) and \fBfreight\-cache\fR(1) to work against the \fBVARLIB\fR and \fBVARCACHE\fR given to \fBfreight init\fR\.
 .
 .P
-The benefit of using \fBfreight\-init\fR is, that all data is stored in one place and dont have to pass \fB\-c _conf_\fR option all the time\.
+The benefit of using \fBfreight\-init\fR is to automate the setup of Freight and to configure all data to be stored in one directory\.
 .
 .P
-Configuration is stored in \fB_dirname_/\.freight\.conf\fR\.
+Configuration is stored in \fIdirname\fR\fB/etc/freight\.conf\fR\.
 .
 .SH "OPTIONS"
 .
 .TP
-\fB\-g\fR \fIgpg\fR, \fB\-\-gpg=\fR\fIgpg\fR`
+\fB\-g\fR \fIgpg\fR, \fB\-\-gpg=\fR\fIgpg\fR
 GPG key\. May be given multiple times\.
 .
 .TP
-\fB\-l\fR \fIvarlib\fR, \fB\-\-varlib=\fR\fIvarlib\fB_\fR\fR
-VARLIB directory to use\. Defaults todirname_/lib`
+\fB\-\-libdir=\fR\fIvarlib\fR
+VARLIB directory to use\. Defaults to \fIdirname\fR\fB/var/lib\fR
 .
 .TP
-\fB\-\-varcache=\fR\fIvarcache\fB_\fR\fR
-VARCACHE directory to use\. Defaults todirname_/cache`
+\fB\-\-cachedir=\fR\fIvarcache\fR
+VARCACHE directory to use\. Defaults to \fIdirname\fR\fB/var/cache\fR
+.
+.TP
+\fB\-\-archs=\fR\fIarchs\fR
+Architectures to generate archives for\. Defaults to \fBi386 amd64\fR
+.
+.TP
+\fB\-\-origin=\fR\fIorigin\fR
+Debian archive Origin field value\. Defaults to \fBFreight\fR
+.
+.TP
+\fB\-\-label=\fR\fIlabel\fR
+Debian archive Label field value\. Defaults to \fBFreight\fR
+.
+.TP
+\fB\-\-suite=\fR\fIsuite\fR
+Debian archive Suite field value\.
 .
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR

--- a/man/man1/freight-init.1.ronn
+++ b/man/man1/freight-init.1.ronn
@@ -3,24 +3,32 @@ freight-init(1) -- initialize a Freight directory
 
 ## SYNOPSIS
 
-`freight init` [`-l` _varlib_] [`--cache` _varcache_] `-g` _gpg_ _dirname_
+`freight init` [`--libdir` _varlib_] [`--cachedir` _varcache_] [`--archs` _archs_] [`--origin` _origin_] [`--label` _label_] [`-v`] [`-h`] `-g` _gpg_ _dirname_
 
 ## DESCRIPTION
 
-`freight-init` will setup a directory to be used by Freight.  It will generate small wrappers around the original Freight commands.  Use `./freight-add` and `./freight-cache` to work against the `VARLIB` and `VARCACHE` given to `freight init`.
+`freight-init` will setup a directory to be used by Freight.  It will generate small wrappers around the original Freight commands.  Use `freight-add`(1) and `freight-cache`(1) to work against the `VARLIB` and `VARCACHE` given to `freight init`.
 
-The benefit of using `freight-init` is, that all data is stored in one place and dont have to pass `-c _conf_` option all the time.
+The benefit of using `freight-init` is to automate the setup of Freight and to configure all data to be stored in one directory.
 
-Configuration is stored in `_dirname_/.freight.conf`.
+Configuration is stored in _dirname_`/etc/freight.conf`.
 
 ## OPTIONS
 
-* `-g` _gpg_, `--gpg=`_gpg_`:
+* `-g` _gpg_, `--gpg=`_gpg_:
   GPG key.  May be given multiple times.
-* `-l` _varlib_, `--varlib=`_varlib`_:
-  VARLIB directory to use.  Defaults to `_dirname_/lib`
-* `--varcache=`_varcache`_:
-  VARCACHE directory to use.  Defaults to `_dirname_/cache`
+* `--libdir=`_varlib_:
+  VARLIB directory to use.  Defaults to _dirname_`/var/lib`
+* `--cachedir=`_varcache_:
+  VARCACHE directory to use.  Defaults to _dirname_`/var/cache`
+* `--archs=`_archs_:
+  Architectures to generate archives for.  Defaults to `i386 amd64`
+* `--origin=`_origin_:
+  Debian archive Origin field value.  Defaults to `Freight`
+* `--label=`_label_:
+  Debian archive Label field value.  Defaults to `Freight`
+* `--suite=`_suite_:
+  Debian archive Suite field value.
 * `-v`, `--verbose`:
   Verbose mode.
 * `-h`, `--help`:


### PR DESCRIPTION
Fix formatting of paths, fix missing supported arguments and fix names
of existing libdir/cachedir args.