### PR TITLE
use UTC timezone for Date fields

### DIFF
--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -81,8 +81,8 @@ apt_filesize() {
 # Setup the repository for the distro named in the first argument,
 # including all packages read from `stdin`.
 apt_cache() {
-    REL_DATE="$(LC_ALL=en_US date '+%a, %d %b %Y %H:%M:%S %Z')"
-    VALID_DATE="Tue, 30 Nov 2038 00:00:00 JST"
+    REL_DATE="$(LC_ALL=en_US date -u '+%a, %d %b %Y %H:%M:%S %Z')"
+    VALID_DATE="Tue, 30 Nov 2038 00:00:00 UTC"
     DIST="$1"
     SUITE="${SUITE:-$DIST}"
 


### PR DESCRIPTION
apt- 1.3 arrived in Debian/testing today and I'm getting the following warnings:
```
W: Invalid 'Date' entry in Release file /var/lib/apt/lists/partial/space.kvedulv.de_apt_dists_stretch_Release
W: The repository 'http://space.kvedulv.de/apt stretch Release' provides only weak security information.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```
The first line is from the server having the local time zone (CEST in my case) set and the other three ones from the `Valid-Date` field not being in UTC.