### PR TITLE
Change freight apt repository URL to a non-deprecated one

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Serve `/var/cache/freight` via your favorite web server and install it as an APT
 ### From a Debian archive
 
 	wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg|sudo apt-key add -
-	echo "deb http://build.openvpn.net/freight_team $(lsb_release -sc) main" | sudo tee  /etc/apt/sources.list.d/freight.list
+	echo "deb http://build.openvpn.net/debian/freight_team $(lsb_release -sc) main" | sudo tee  /etc/apt/sources.list.d/freight.list
 	sudo apt-get update
 	sudo apt-get -y install freight
 


### PR DESCRIPTION
The location of the freight apt repository has changed on the webserver. While compatibility links are in place, new users should be pointed to the correct, new URL.