### PR TITLE
Prevent GPG >= 2.1 from using .kbx pubring format during import

### DIFF
--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -226,11 +226,13 @@ EOF
     # the appropriate public keys.  `keyring.gpg` is appropriate for
     # copying directly to `/etc/apt/trusted.gpg.d`.
     mkdir -m700 -p "$TMP/gpg"
+    # Create `pubring.gpg` to prevent gpg version >= 2.1 from using the
+    # new `pubring.kbx` format during an initial `gpg --import`.
+    : > "$TMP/gpg/pubring.gpg" && chmod 644 "$TMP/gpg/pubring.gpg"
     # shellcheck disable=SC2086
     gpg -q --export -a $GPG |
     tee "$VARCACHE/pubkey.gpg" |
     gpg -q --homedir "$TMP/gpg" --import
-    chmod 644 "$TMP/gpg/pubring.gpg"
     mv "$TMP/gpg/pubring.gpg" "$VARCACHE/keyring.gpg"
 
     # Move the symbolic link for this distro to this build.


### PR DESCRIPTION
As described here[1], if pubring.gpg already exists, .kbx format will
not be used. This fixes tests for new GPG versions that otherwise
failed due to `pubring.gpg` not existing after `gpg --import` into
`$TMP/gpg`.

1: https://www.gnupg.org/faq/whats-new-in-2.1.html

Without this commit:

    $ cat /etc/os-release
    NAME="Arch Linux"
    PRETTY_NAME="Arch Linux"
    ID=arch
    ID_LIKE=archlinux
    ANSI_COLOR="0;36"
    HOME_URL="https://www.archlinux.org/"
    SUPPORT_URL="https://bbs.archlinux.org/"
    BUG_REPORT_URL="https://bugs.archlinux.org/"
    $ gpg --version
    gpg (GnuPG) 2.1.17
    $ git log -n 1
    commit 4f412fa6daded0cac6b8f9b4f5c643343a9cb36f
    Author: Stephen Ryan <ryaner@users.noreply.github.com>
    Date:   Tue Nov 22 09:19:21 2016 +0000
    
        Let install-man task work on second and subsequent attempts
        
        gzip would previously fail due to the existing man pages
        
        Fixes GH-44
    $ make check
    git clone --depth 1 https://github.com/sstephenson/bats.git test/tmp/bats
    Cloning into 'test/tmp/bats'...
    remote: Counting objects: 61, done.
    remote: Compressing objects: 100% (48/48), done.
    remote: Total 61 (delta 0), reused 45 (delta 0), pack-reused 0
    Unpacking objects: 100% (61/61), done.
    git clone --depth 1 https://github.com/jasonkarns/bats-assert.git test/tmp/bats-assert
    Cloning into 'test/tmp/bats-assert'...
    remote: Counting objects: 24, done.
    remote: Compressing objects: 100% (19/19), done.
    remote: Total 24 (delta 7), reused 13 (delta 4), pack-reused 0
    Unpacking objects: 100% (24/24), done.
    mkdir -p test/tmp/bin
    ln -sf $(which dash) test/tmp/bin/sh
    PATH=test/tmp/bin/:$PATH test/tmp/bats/bin/bats test/
     ✗ freight-add adds package to distro main component
       (from function `gpg_init' in file test/freight_helpers.bash, line 45,
        from function `freight_init' in file test/freight_helpers.bash, line 17,
        from function `setup' in test file test/apt_add.bats, line 6)
         `freight_init' failed with status 2
       gpg: keybox '/home/jeremy/src/freight-team/test/tmp/gpg/pubring.kbx' created
       gpg: agent_genkey failed: Operation cancelled
       gpg: key generation failed: Operation cancelled
     ✓ freight-add adds package to a component
     ✓ freight-add adds package and hard link to multiple components
     ✓ freight-add detects duplicate package
     ✓ freight-add adds source .dsc files
     ✓ freight-add adds source .tar.gz files
     ✓ freight-add adds source .orig.tar.gz files
     ✓ freight-add handles VARLIB being a symlink
     ✗ freight-cache builds distro Release file
       (from function `freight_cache' in file test/freight_helpers.bash, line 33,
        in test file test/apt_cache.bats, line 14)
         `freight_cache -v' failed
       # [freight] added /home/jeremy/src/freight-team/test/fixtures/test_1.0_all.deb to apt/example
       # [freight] added /home/jeremy/src/freight-team/test/fixtures/test_1.0_all.deb to apt/example/comp
       # [freight] adding test_1.0_all.deb to pool
       # [freight] adding test_1.0_all.deb to pool
       gpg: skipped "freight@example.com": No secret key
       gpg: signing failed: No secret key
       # [freight] couldn't sign the repository, perhaps you need to run
       # [freight] gpg --gen-key and update the GPG setting in /home/jeremy/src/freight-team/test/tmp/freight/etc/freight.conf
       # [freight] (see freight(5) for more information)

With it:

    $ make check
    ln -sf $(which dash) test/tmp/bin/sh
    PATH=test/tmp/bin/:$PATH test/tmp/bats/bin/bats test/
     ✓ freight-add adds package to distro main component
     ✓ freight-add adds package to a component
     ✓ freight-add adds package and hard link to multiple components
     ✓ freight-add detects duplicate package
     ✓ freight-add adds source .dsc files
     ✓ freight-add adds source .tar.gz files
     ✓ freight-add adds source .orig.tar.gz files
     ✓ freight-add handles VARLIB being a symlink
     ✓ freight-cache builds distro Release file
     ✓ freight-cache builds per-component Release file
     ✓ freight-cache builds pool
     ✓ freight-cache generates valid Release.gpg signature
     ✓ freight-cache signs Release.gpg with two keys
     ✓ freight-cache works without tty
     - apt-get fetches package list (skipped: missing apt-get)
     ✓ freight-cache removes deleted packages from pool
     ✓ freight-cache --keep retains deleted packages in pool
     ✓ freight-cache handles VARLIB being a symlink
     ✓ freight-cache skips partial source packages
     ✓ freight-cache builds source-only archive
     - apt-get fetches source package list (skipped: missing apt-get)

Tested on debian:

    $ sudo make clean
    rm -rf *.deb deb man/man*/*.html test/tmp
    find . -name '*~' -delete
    $ git log --pretty=oneline --abbrev-commit -n 1
    1c9b5a2 Prevent GPG >= 2.1 from using .kbx pubring format
    $ docker run -it -v $(pwd):/freight debian:stable /bin/bash -c 'apt-get update &>/dev/null; apt-get install --no-install-recommends -y git make ca-certificates &>/dev/null; cd /freight && make check'
    git clone --depth 1 https://github.com/sstephenson/bats.git test/tmp/bats
    Cloning into 'test/tmp/bats'...
    remote: Counting objects: 61, done.
    remote: Compressing objects: 100% (48/48), done.
    remote: Total 61 (delta 0), reused 45 (delta 0), pack-reused 0
    Unpacking objects: 100% (61/61), done.
    Checking connectivity... done.
    git clone --depth 1 https://github.com/jasonkarns/bats-assert.git test/tmp/bats-assert
    Cloning into 'test/tmp/bats-assert'...
    remote: Counting objects: 24, done.
    remote: Compressing objects: 100% (19/19), done.
    remote: Total 24 (delta 7), reused 13 (delta 4), pack-reused 0
    Unpacking objects: 100% (24/24), done.
    Checking connectivity... done.
    mkdir -p test/tmp/bin
    ln -sf $(which dash) test/tmp/bin/sh
    PATH=test/tmp/bin/:$PATH test/tmp/bats/bin/bats test/
     ✓ freight-add adds package to distro main component
     ✓ freight-add adds package to a component
     ✓ freight-add adds package and hard link to multiple components
     ✓ freight-add detects duplicate package
     ✓ freight-add adds source .dsc files
     ✓ freight-add adds source .tar.gz files
     ✓ freight-add adds source .orig.tar.gz files
     ✓ freight-add handles VARLIB being a symlink
     ✓ freight-cache builds distro Release file
     ✓ freight-cache builds per-component Release file
     ✓ freight-cache builds pool
     ✓ freight-cache generates valid Release.gpg signature
     ✓ freight-cache signs Release.gpg with two keys
     ✓ freight-cache works without tty
     ✓ apt-get fetches package list
     ✓ freight-cache removes deleted packages from pool
     ✓ freight-cache --keep retains deleted packages in pool
     ✓ freight-cache handles VARLIB being a symlink
     ✓ freight-cache skips partial source packages
     ✓ freight-cache builds source-only archive
     ✓ apt-get fetches source package list
    
    21 tests, 0 failures