### PR TITLE
Error messages suppressing and support bz2 orig files.

### DIFF
--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -307,7 +307,7 @@ EOF
 
     # Link or copy this package into this distro's `.refs` directory.
     mkdir -p "$DISTCACHE/.refs/$COMP"
-    ln "$VARLIB/apt/$DIST/$PATHNAME" "$DISTCACHE/.refs/$COMP" ||
+    ln "$VARLIB/apt/$DIST/$PATHNAME" "$DISTCACHE/.refs/$COMP" > /dev/null 2>&1 ||
     cp "$VARLIB/apt/$DIST/$PATHNAME" "$DISTCACHE/.refs/$COMP"
 
     # Package properties.  Remove the epoch from the version number
@@ -404,7 +404,7 @@ apt_cache_source() {
     do
         [ -f "$VARLIB/apt/$DIST/$DIRNAME/$FILENAME" ] || continue
         [ -f "$DISTCACHE/.refs/$COMP/$FILENAME" ] ||
-        ln "$VARLIB/apt/$DIST/$DIRNAME/$FILENAME" "$DISTCACHE/.refs/$COMP" ||
+        ln "$VARLIB/apt/$DIST/$DIRNAME/$FILENAME" "$DISTCACHE/.refs/$COMP" > /dev/null 2>&1 ||
         cp "$VARLIB/apt/$DIST/$DIRNAME/$FILENAME" "$DISTCACHE/.refs/$COMP"
     done
 

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -371,7 +371,8 @@ apt_cache_source() {
     DEBTAR_XZ_FILENAME="${NAME}_${VERSION%*:}.debian.tar.xz"
     DEBTAR_LZMA_FILENAME="${NAME}_${VERSION%*:}.debian.tar.lzma"
     DIFFGZ_FILENAME="${NAME}_${VERSION%*:}.diff.gz"
-    ORIG_FILENAME="${NAME}_${ORIG_VERSION}.orig.tar.gz"
+    ORIG_GZ_FILENAME="${NAME}_${ORIG_VERSION}.orig.tar.gz"
+    ORIG_BZ2_FILENAME="${NAME}_${ORIG_VERSION}.orig.tar.bz2"
     TAR_FILENAME="${NAME}_${VERSION%*:}.tar.gz"
 
     # Find which style of diff they're using.
@@ -384,6 +385,12 @@ apt_cache_source() {
     elif [ -f "$VARLIB/apt/$DIST/$DIRNAME/$DEBTAR_LZMA_FILENAME" ]
     then DIFF_FILENAME=${DEBTAR_LZMA_FILENAME}
     else DIFF_FILENAME=${DIFFGZ_FILENAME}
+    fi
+
+    # Find which style of orig they're using.
+    if [ -f "$VARLIB/apt/$DIST/$DIRNAME/$ORIG_BZ2_FILENAME" ]
+    then ORIG_FILENAME=${ORIG_BZ2_FILENAME}
+    else ORIG_FILENAME=${ORIG_GZ_FILENAME}
     fi
 
     # Verify this package by ensuring the other necessary files are present.


### PR DESCRIPTION
1. Suppress error messages when link can't be created and files will be copied instead.
2. Support bz2 compressed orig files.