### PR TITLE
Learn NotAutomatic and ButAutomaticUpgrades release fields

### DIFF
--- a/etc/freight.conf.example
+++ b/etc/freight.conf.example
@@ -5,9 +5,12 @@
 VARLIB="/var/lib/freight"
 VARCACHE="/var/cache/freight"
 
-# Default `Origin` and `Label` fields for `Release` files.
+# Default `Origin`, `Label`, `NotAutomatic`, and
+# `ButAutomaticUpgrades` fields for `Release` files.
 ORIGIN="Freight"
 LABEL="Freight"
+NOT_AUTOMATIC="no"
+BUT_AUTOMATIC_UPGRADES="no"
 
 # Cache the control files after each run (on), or regenerate them every
 # time (off).

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -138,6 +138,8 @@ Archive: $SUITE
 Component: $COMP
 Origin: $ORIGIN
 Label: $LABEL
+NotAutomatic: $NOT_AUTOMATIC
+ButAutomaticUpgrades: $BUT_AUTOMATIC_UPGRADES
 Architecture: $ARCH
 Date: $REL_DATE
 Valid-Until: $VALID_DATE
@@ -153,6 +155,8 @@ Archive: $SUITE
 Component: $COMP
 Origin: $ORIGIN
 Label: $LABEL
+NotAutomatic: $NOT_AUTOMATIC
+ButAutomaticUpgrades: $BUT_AUTOMATIC_UPGRADES
 Architecture: source
 Date: $REL_DATE
 Valid-Until: $VALID_DATE
@@ -171,6 +175,8 @@ Origin: $ORIGIN
 Label: $LABEL
 Suite: $SUITE
 Codename: $DIST
+NotAutomatic: $NOT_AUTOMATIC
+ButAutomaticUpgrades: $BUT_AUTOMATIC_UPGRADES
 Components: $(echo "$COMPS" | tr \\n " ")
 Architectures: $ARCHS
 Date: $REL_DATE

--- a/lib/freight/conf.sh
+++ b/lib/freight/conf.sh
@@ -9,11 +9,16 @@ VARCACHE="/var/cache/freight"
 # shellcheck disable=SC2034
 ARCHS="i386 amd64"
 
-# Default `Origin` and `Label` fields for `Release` files.
+# Default `Origin`, `Label`, 'NotAutomatic`, and
+# `ButAutomaticUpgrades` fields for `Release` files.
 # shellcheck disable=SC2034
 ORIGIN="Freight"
 # shellcheck disable=SC2034
 LABEL="Freight"
+# shellcheck disable=SC2034
+NOT_AUTOMATIC="no"
+# shellcheck disable=SC2034
+BUT_AUTOMATIC_UPGRADES="no"
 
 # shellcheck disable=SC2034
 CACHE="off"

--- a/man/man5/freight.5
+++ b/man/man5/freight.5
@@ -32,6 +32,14 @@ The \fBOrigin\fR field in the Debian archive\.
 The \fBLabel\fR field in the Debian archive\.
 .
 .TP
+\fBNOT_AUTOMATIC\fR
+The \fBNotAutomatic\fR field in the Debian archive\.
+.
+.TP
+\fBBUT_AUTOMATIC_UGPRADES\fR
+The \fBButAutomaticUpgrades\fR field in the Debian archive\.
+.
+.TP
 \fBCACHE\fR
 \fIon\fR to cache package control files or \fIoff\fR to read them from the packages on each \fBfreight\-cache\fR(1) run\.
 .


### PR DESCRIPTION
These fields are necessary to create a release like `jessie-backports`.