### PR TITLE
Support 'ddeb' file extension

### DIFF
--- a/bin/freight-add
+++ b/bin/freight-add
@@ -39,7 +39,7 @@ done
 # to be `<manager>/<distro>` pairs for this (source) package.
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        *.deb | *.dsc | *.orig.tar.gz | *.orig.tar.bz2 | *.orig.tar.xz | *.orig.tar.lzma | *.diff.gz | *.debian.tar.gz | *.debian.tar.bz2 | *.debian.tar.xz | *.debian.tar.lzma | *.tar.gz | *.tar.bz2 | *.tar.xz | *.tar.lzma)
+        *.deb | *.ddeb | *.dsc | *.orig.tar.gz | *.orig.tar.bz2 | *.orig.tar.xz | *.orig.tar.lzma | *.diff.gz | *.debian.tar.gz | *.debian.tar.bz2 | *.debian.tar.xz | *.debian.tar.lzma | *.tar.gz | *.tar.bz2 | *.tar.xz | *.tar.lzma)
             # shellcheck disable=SC2153
             PATHNAMES="$PATHNAMES $1" shift
             ;;
@@ -88,8 +88,8 @@ for PATHNAME in $PATHNAMES; do
     for DIRNAME in "$@"; do
         mkdir -p "$DIRNAME"
         case "$FILENAME" in
-            *_*_*.deb) add "$FILENAME" "$DIRNAME" "$PATHNAME" ;;
-            *.deb)
+            *_*_*.deb | *_*_*.ddeb) add "$FILENAME" "$DIRNAME" "$PATHNAME" ;;
+            *.deb | *.ddeb)
                 . "$(dirname "$(dirname "$0")")/lib/freight/apt.sh"
                 dpkg-deb -I "$TMP/$FILENAME" "control" >"$TMP/$FILENAME-control"
                 DEBNAME="$(
@@ -98,7 +98,7 @@ for PATHNAME in $PATHNAMES; do
                     apt_binary_version "$TMP/$FILENAME-control"
                 )_$(
                     apt_binary_arch "$TMP/$FILENAME-control"
-                ).deb"
+                ).${FILENAME##*.}"
                 add "$FILENAME" "$DIRNAME" "$PATHNAME" "$DEBNAME"
                 ;;
             *) add "$FILENAME" "$DIRNAME" "$PATHNAME" ;;

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -110,7 +110,7 @@ apt_cache() {
         case "$PATHNAME" in
 
             # Binary packages.
-            *.deb) apt_cache_binary "$DIST" "$DISTCACHE" "$PATHNAME" "$COMP" "$PACKAGE" ;;
+            *.deb | *.ddeb) apt_cache_binary "$DIST" "$DISTCACHE" "$PATHNAME" "$COMP" "$PACKAGE" ;;
 
             # Source packages.  The *.dsc file is considered the "entrypoint"
             # and will find the associated *.orig.tar.gz, *.diff.gz, and/or
@@ -332,7 +332,7 @@ EOF
     VERSION="$(apt_binary_version "$CONTROL")"
     PREFIX="$(apt_binary_prefix "$CONTROL")"
     SOURCE="$(apt_binary_sourcename "$CONTROL")"
-    FILENAME="${NAME}_${VERSION##*:}_${ARCH}.deb"
+    FILENAME="${NAME}_${VERSION##*:}_${ARCH}.${PATHNAME##*.}"
 
     # Link this package into the pool.
     POOL="pool/$DIST/$COMP/$PREFIX/$SOURCE"

--- a/man/man1/freight-add.1
+++ b/man/man1/freight-add.1
@@ -10,7 +10,7 @@
 \fBfreight add\fR [\fB\-c\fR \fIconf\fR] [\fB\-v\fR] [\fB\-h\fR] \fIpackage\fR \fImanager\fR/\fIdistro\fR[/\fIcomponent\fR][\.\.\.]
 .
 .SH "DESCRIPTION"
-\fBfreight\-add\fR registers \fIpackage\fR with one or more \fImanager\fR/\fIdistro\fR[/\fIcomponent\fR] pairs (or triples)\. Currently, \fBapt\fR is the only supported \fImanager\fR and \fIpackage\fR must be one of \fI*\.deb\fR, \fI*\.dsc *\.debian\.tar\.gz *\.orig\.tar\.gz\fR, \fI*\.dsc *\.diff\.gz *\.orig\.tar\.gz\fR, or \fI*\.dsc *\.tar\.gz\fR\. \fIdistro\fR may be any arbitrary value but is best suited to naming a particular version of the target operating system (for example, "wheezy" or "precise")\. \fIcomponent\fR is optional and for \fBapt\fR defaults to \fBmain\fR\.
+\fBfreight\-add\fR registers \fIpackage\fR with one or more \fImanager\fR/\fIdistro\fR[/\fIcomponent\fR] pairs (or triples)\. Currently, \fBapt\fR is the only supported \fImanager\fR and \fIpackage\fR must be one of \fI*\.deb\fR, \fI*\.ddeb\fR, \fI*\.dsc *\.debian\.tar\.gz *\.orig\.tar\.gz\fR, \fI*\.dsc *\.diff\.gz *\.orig\.tar\.gz\fR, or \fI*\.dsc *\.tar\.gz\fR\. \fIdistro\fR may be any arbitrary value but is best suited to naming a particular version of the target operating system (for example, "wheezy" or "precise")\. \fIcomponent\fR is optional and for \fBapt\fR defaults to \fBmain\fR\.
 .
 .P
 The package files are organized in the Freight library so \fBfreight\-cache\fR(1) has an easy time of creating package repositories for each \fImanager\fR/\fIdistro\fR[/\fIcomponent\fR] later\.

--- a/man/man1/freight-add.1.ronn
+++ b/man/man1/freight-add.1.ronn
@@ -7,7 +7,7 @@ freight-add(1) -- add a package to Freight
 
 ## DESCRIPTION
 
-`freight-add` registers _package_ with one or more _manager_/_distro_[/_component_] pairs (or triples).  Currently, `apt` is the only supported _manager_ and _package_ must be one of _\*.deb_, _\*.dsc \*.debian.tar.gz \*.orig.tar.gz_, _\*.dsc \*.diff.gz \*.orig.tar.gz_, or _\*.dsc \*.tar.gz_.  _distro_ may be any arbitrary value but is best suited to naming a particular version of the target operating system (for example, "wheezy" or "precise").  _component_ is optional and for `apt` defaults to `main`.
+`freight-add` registers _package_ with one or more _manager_/_distro_[/_component_] pairs (or triples).  Currently, `apt` is the only supported _manager_ and _package_ must be one of _\*.deb_, _\*.ddeb_, _\*.dsc \*.debian.tar.gz \*.orig.tar.gz_, _\*.dsc \*.diff.gz \*.orig.tar.gz_, or _\*.dsc \*.tar.gz_.  _distro_ may be any arbitrary value but is best suited to naming a particular version of the target operating system (for example, "wheezy" or "precise").  _component_ is optional and for `apt` defaults to `main`.
 
 The package files are organized in the Freight library so `freight-cache`(1) has an easy time of creating package repositories for each _manager_/_distro_[/_component_] later.
 


### PR DESCRIPTION
Adds support for the `.ddeb` extension, currently in use by Ubuntu for [packages with debug symbols](https://wiki.ubuntu.com/AptElfDebugSymbols).