### PR TITLE
Port CI to GitHub Actions

### DIFF
--- a/.github/workflows/freight-tests.yml
+++ b/.github/workflows/freight-tests.yml
@@ -1,0 +1,21 @@
+name: freight-tests
+on: [push]
+jobs:
+  perform-bash-ci:
+    runs-on: ubuntu-latest
+    env:
+      GPG_TTY: $(tty)
+      FREIGHT_GPG_KEY_FIRST: ${{ secrets.FREIGHT_GPG_KEY_FIRST }}
+      FREIGHT_GPG_KEY_SECOND: ${{ secrets.FREIGHT_GPG_KEY_SECOND }}
+      FREIGHT_KEY_PASSWD: ${{ secrets.FREIGHT_KEY_PASSWD }}
+      GNUPGHOME: test/tmp/gpg
+    steps:
+      - uses: actions/checkout@v2
+      - run: mkdir -p "$GNUPGHOME"
+      - run: chmod 0700 "$GNUPGHOME"
+      - run: echo -n "$FREIGHT_GPG_KEY_FIRST" | base64 --decode > key_first.gpg
+      - run: echo -n "$FREIGHT_GPG_KEY_SECOND" | base64 --decode > key_second.gpg
+      - run: echo "$FREIGHT_KEY_PASSWD" | gpg --batch --yes --passphrase-fd 0 --import key_first.gpg
+      - run: echo "$FREIGHT_KEY_PASSWD" | gpg --batch --yes --passphrase-fd 0 --import key_second.gpg
+      - run: echo "$FREIGHT_KEY_PASSWD" > test/tmp/passphrase
+      - run: make check

--- a/test/freight_helpers.bash
+++ b/test/freight_helpers.bash
@@ -31,7 +31,11 @@ freight_add() {
 }
 
 freight_cache() {
-    bin/freight cache -c $FREIGHT_CONFIG "$@"
+    if [ ! -e "$TMPDIR"/passphrase ]; then
+        bin/freight cache -c $FREIGHT_CONFIG "$@"
+    else
+        bin/freight cache -p "$TMPDIR"/passphrase -c $FREIGHT_CONFIG "$@"
+    fi
 }
 
 freight_cache_nohup() {


### PR DESCRIPTION
GitHub repository needs two secrets and a passphrase that will be
imported before the make check can be invoked:

- FREIGHT_GPG_KEY_FIRST
- FREIGHT_GPG_KEY_SECOND
- FREIGHT_KEY_PASSWD

To avoid interactive password request from apt a passphrase file
will be used.