### PR TITLE
Tests: initialize default archs

### DIFF
--- a/test/freight_helpers.bash
+++ b/test/freight_helpers.bash
@@ -22,6 +22,7 @@ freight_init() {
         -c $FREIGHT_CONFIG \
         --libdir $FREIGHT_LIB \
         --cachedir $FREIGHT_CACHE \
+        --archs "i386 amd64" \
         "$@"
 }
 


### PR DESCRIPTION
If the system already has a freight.conf with another arch, this
will make the "freight-cache builds per-component Release file"
test fail as it awaits "binary-amd64" folder.