### PR TITLE
Tests: fix apt-get errors

### DIFF
--- a/test/apt_helpers.bash
+++ b/test/apt_helpers.bash
@@ -3,7 +3,15 @@
 configure_local_apt() {
     mkdir -p ${TMPDIR}/apt/etc/apt
     mkdir -p ${TMPDIR}/apt/var/lib/apt
+    mkdir -p ${TMPDIR}/apt/var/lib/dpkg
     mkdir -p ${TMPDIR}/apt/var/cache/apt
+
+    if [ ! -e "${TMPDIR}"/apt/var/lib/dpkg/status ]; then
+        touch "${TMPDIR}"/apt/var/lib/dpkg/status
+    fi
+    if [ ! -e "$TMPDIR"/apt/etc/apt/trusted.gpg ]; then
+        gpg --output "$TMPDIR"/apt/etc/apt/trusted.gpg --export freight@example.com
+    fi
 }
 
 check_apt_support() {


### PR DESCRIPTION
Export our key so apt can use it as trusted key.

Create an empty status file.