### PR TITLE
Add .dir-locals.el for setting sh-basic-offset

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((sh-mode . ((sh-basic-offset . 4))))


### PR DESCRIPTION
This instructs emacs to use an indentation of 4 spaces to avoid issues with
unnecessary reformatting after changes.