### PR TITLE
Configurable working directory

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -78,9 +78,11 @@ LIB="$(cd "$(dirname "$(dirname "$0")")/lib/freight" && pwd)"
 # If `GPG_DIGEST_ALGO` is unset, force it to the freight default of SHA512
 [ -z "$GPG_DIGEST_ALGO" ] && GPG_DIGEST_ALGO="SHA512"
 
-# Create a working directory on the same device as the Freight cache.
+# make sure the cache-directory exists
 mkdir -p "$VARCACHE"
-TMP="$(mktemp -d "$VARCACHE/work.$$.XXXXXXXXXX")"
+
+# Create a temporary working directory for extracting files
+TMP="$(mktemp -d "/tmp/work.$$.XXXXXXXXXX")"
 # shellcheck disable=SC2064
 trap "rm -rf \"$TMP\"" EXIT INT TERM
 

--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -82,7 +82,7 @@ LIB="$(cd "$(dirname "$(dirname "$0")")/lib/freight" && pwd)"
 mkdir -p "$VARCACHE"
 
 # Create a temporary working directory for extracting files
-TMP="$(mktemp -d "/tmp/work.$$.XXXXXXXXXX")"
+TMP="$(mktemp -d "$TEMPDIR/work.$$.XXXXXXXXXX")"
 # shellcheck disable=SC2064
 trap "rm -rf \"$TMP\"" EXIT INT TERM
 

--- a/bin/freight-init
+++ b/bin/freight-init
@@ -2,11 +2,12 @@
 
 # Initialize a Freight directory (similar to git init).
 
-#/ Usage: freight init -g<email> [--libdir=<libdir>] [--cachedir=<cachedir>] [--archs=<archs>] [--origin=<origin>] [--label=<label>] [-v] [-h] [<dirname>]
+#/ Usage: freight init -g<email> [--libdir=<libdir>] [--cachedir=<cachedir>] [--workdir=<workdir>] [--archs=<archs>] [--origin=<origin>] [--label=<label>] [-v] [-h] [<dirname>]
 #/   -g<email>, --gpg=<email> GPG key to use
 #/   -c<conf>, --conf=<conf>  config file to create (default etc/freight.conf)
 #/   --libdir=<libdir>        library directory (default var/lib/freight)
 #/   --cachedir=<cachedir>    cache directory (default var/cache/freight)
+#/   --tempdir=<tempdir>      temp directory (default same as cachedir)
 #/   --archs=<archs>          architectures to support (default "i386 amd64")
 #/   --origin=<origin>        Debian archive Origin field (default "Freight")
 #/   --label=<label>          Debian archive Label field (default "Freight")
@@ -56,6 +57,8 @@ while [ "$#" -gt 0 ]; do
         --libdir=*) VARLIB="$(echo "$1" | cut -c"10-")" shift ;;
         --cachedir) VARCACHE="$2" shift 2 ;;
         --cachedir=*) VARCACHE="$(echo "$1" | cut -c"12-")" shift ;;
+        --tempdir) TEMPDIR="$2" shift 2 ;;
+        --tempdir=*) TEMPDIR="$(echo "$1" | cut -c"12-")" shift ;;
         --archs) ARCHS="$2" shift 2 ;;
         --archs=*) ARCHS="$(echo "$1" | cut -c"9-")" shift ;;
         --origin) ORIGIN="$2" shift 2 ;;
@@ -80,6 +83,7 @@ DIRNAME="$(cd "${1:-"."}" && pwd)"
 # follows the FHS style.
 VARLIB="${VARLIB:-"$DIRNAME/var/lib"}"
 VARCACHE="${VARCACHE:-"$DIRNAME/var/cache"}"
+WORKDIR="${TEMPDIR:-"$DIRNAME/var/cache"}"
 
 # Create the directory where `CONF` will be placed.  This is likely given
 # relative to `DIRNAME` so change to that directory to make things easy.
@@ -91,6 +95,7 @@ mkdir -p "$(dirname "$CONF")"
 cat >"$CONF" <<EOF
 VARLIB="$VARLIB"
 VARCACHE="$VARCACHE"
+TEMPDIR="$TEMPDIR"
 GPG="$GPG"
 EOF
 [ "$ARCHS" ] && echo "ARCHS=\"$ARCHS\"" >>"$CONF"

--- a/etc/freight.conf.example
+++ b/etc/freight.conf.example
@@ -5,6 +5,12 @@
 VARLIB="/var/lib/freight"
 VARCACHE="/var/cache/freight"
 
+# The dir used for temp files when regenerating the cache. It's efficient
+# to set this to the same value as VARCACHE, but that will expose temp files
+# for a short period of time to the outside world. To avoid this, set it
+# to something else (for example /tmp)
+TEMPDIR="/var/cache/freight"
+
 # Default `Origin`, `Label`, `NotAutomatic`, and
 # `ButAutomaticUpgrades` fields for `Release` files.
 ORIGIN="Freight"

--- a/lib/freight/conf.sh
+++ b/lib/freight/conf.sh
@@ -5,6 +5,7 @@
 # web server's document root should be `$VARCACHE`.
 VARLIB="/var/lib/freight"
 VARCACHE="/var/cache/freight"
+TEMPDIR="/var/cache/freight"
 
 # Default architectures.
 # shellcheck disable=SC2034

--- a/man/man1/freight-init.1.ronn
+++ b/man/man1/freight-init.1.ronn
@@ -3,7 +3,7 @@ freight-init(1) -- initialize a Freight directory
 
 ## SYNOPSIS
 
-`freight init` [`--libdir` _varlib_] [`--cachedir` _varcache_] [`--archs` _archs_] [`--origin` _origin_] [`--label` _label_] [`-v`] [`-h`] `-g` _gpg_ _dirname_
+`freight init` [`--libdir` _varlib_] [`--cachedir` _varcache_] [`--tempdir` _tempdir_] [`--archs` _archs_] [`--origin` _origin_] [`--label` _label_] [`-v`] [`-h`] `-g` _gpg_ _dirname_
 
 ## DESCRIPTION
 
@@ -21,6 +21,8 @@ Configuration is stored in _dirname_`/etc/freight.conf`.
   VARLIB directory to use.  Defaults to _dirname_`/var/lib`
 * `--cachedir=`_varcache_:
   VARCACHE directory to use.  Defaults to _dirname_`/var/cache`
+* `--tempdir=`_tempdir:
+  Directory for temporary files.  Defaults to _dirname_`/var/cache`
 * `--archs=`_archs_:
   Architectures to generate archives for.  Defaults to `i386 amd64`
 * `--origin=`_origin_:

--- a/man/man5/freight.5.ronn
+++ b/man/man5/freight.5.ronn
@@ -11,6 +11,8 @@ The Freight configuration is a `source`d shell script that defines a few importa
   The Freight library directory.  Typically _/var/lib/freight_.
 * `VARCACHE`:
   The Freight cache directory.  Typically _/var/cache/freight_.  This should be the document root of the web server.
+* `TEMPDIR`:
+  Directory for temp files during cache updates. Typically the same as $VARCACHE or /tmp. If you set it to $VARCACHE the temporary files are accessible via the web interface for a short period of time.
 * `ARCHS`:
   The architectures to support.  Typically _i386 amd64_.
 * `ORIGIN`:


### PR DESCRIPTION
Hello,

When running 'freight-cache', a temporary working directory is created in $VARCACHE. And because $VARCACHE is also normally exposed via a webserver, the temporary files in this directory are also accessible from the outside. I'm not sure if this is a vulnerability, maybe it it not even an issue, but I find it not so elegant. In this pull request I added a config-option $TEMPDIR that can be set to use a different temporary directory instead.

Maybe it helps someone.

Emiel Bruijntjes