### PR TITLE
Add udeb file support

### DIFF
--- a/bin/freight-add
+++ b/bin/freight-add
@@ -39,7 +39,7 @@ done
 # to be `<manager>/<distro>` pairs for this (source) package.
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        *.deb | *.ddeb | *.dsc | *.orig.tar.gz | *.orig.tar.bz2 | *.orig.tar.xz | *.orig.tar.lzma | *.diff.gz | *.debian.tar.gz | *.debian.tar.bz2 | *.debian.tar.xz | *.debian.tar.lzma | *.tar.gz | *.tar.bz2 | *.tar.xz | *.tar.lzma | *.git)
+        *.deb | *.ddeb | *.udeb | *.dsc | *.orig.tar.gz | *.orig.tar.bz2 | *.orig.tar.xz | *.orig.tar.lzma | *.diff.gz | *.debian.tar.gz | *.debian.tar.bz2 | *.debian.tar.xz | *.debian.tar.lzma | *.tar.gz | *.tar.bz2 | *.tar.xz | *.tar.lzma | *.git)
             # shellcheck disable=SC2153
             PATHNAMES="$PATHNAMES $1" shift
             ;;
@@ -92,8 +92,8 @@ for PATHNAME in $PATHNAMES; do
     for DIRNAME in "$@"; do
         mkdir -p "$DIRNAME"
         case "$FILENAME" in
-            *_*_*.deb | *_*_*.ddeb) add "$FILENAME" "$DIRNAME" "$PATHNAME" ;;
-            *.deb | *.ddeb)
+            *_*_*.deb | *_*_*.ddeb | *_*_*.udeb) add "$FILENAME" "$DIRNAME" "$PATHNAME" ;;
+            *.deb | *.ddeb | *.udeb)
                 . "$(dirname "$(dirname "$0")")/lib/freight/apt.sh"
                 dpkg-deb -I "$TMP/$FILENAME" "control" >"$TMP/$FILENAME-control"
                 DEBNAME="$(

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -126,7 +126,7 @@ apt_cache() {
         case "$PATHNAME" in
 
             # Binary packages.
-            *.deb | *.ddeb) apt_cache_binary "$DIST" "$DISTCACHE" "$PATHNAME" "$COMP" "$PACKAGE" ;;
+            *.deb | *.ddeb | *.udeb) apt_cache_binary "$DIST" "$DISTCACHE" "$PATHNAME" "$COMP" "$PACKAGE" ;;
 
             # Source packages.  The *.dsc file is considered the "entrypoint"
             # and will find the associated *.orig.tar.*, *.diff.*, *.tar.*, or

--- a/man/man1/freight-add.1.ronn
+++ b/man/man1/freight-add.1.ronn
@@ -7,7 +7,7 @@ freight-add(1) -- add a package to Freight
 
 ## DESCRIPTION
 
-`freight-add` registers _package_ with one or more _manager_/_distro_[/_component_] pairs (or triples).  Currently, `apt` is the only supported _manager_ and _package_ must be one of _\*.deb_, _\*.ddeb_, _\*.dsc \*.debian.tar.\* \*.orig.tar.\*_, _\*.dsc \*.diff.\* \*.orig.tar.\*_,  _\*.dsc \*.tar.\*_, or _\*.dsc \*.git_.  _distro_ may be any arbitrary value but is best suited to naming a particular version of the target operating system (for example, "wheezy" or "precise").  _component_ is optional and for `apt` defaults to `main`.
+`freight-add` registers _package_ with one or more _manager_/_distro_[/_component_] pairs (or triples).  Currently, `apt` is the only supported _manager_ and _package_ must be one of _\*.deb_, _\*.ddeb_, _\*.udeb_, _\*.dsc \*.debian.tar.\* \*.orig.tar.\*_, _\*.dsc \*.diff.\* \*.orig.tar.\*_,  _\*.dsc \*.tar.\*_, or _\*.dsc \*.git_.  _distro_ may be any arbitrary value but is best suited to naming a particular version of the target operating system (for example, "wheezy" or "precise").  _component_ is optional and for `apt` defaults to `main`.
 
 The package files are organized in the Freight library so `freight-cache`(1) has an easy time of creating package repositories for each _manager_/_distro_[/_component_] later.
 


### PR DESCRIPTION
udeb files are stripped down deb files for use by the DebianInstaller.