### PR TITLE
Add a workflow for the manpage generation

### DIFF
--- a/.github/workflows/freight-man-pages.yml
+++ b/.github/workflows/freight-man-pages.yml
@@ -1,0 +1,16 @@
+name: freight-man-pages
+on: [push, pull_request]
+jobs:
+  generate-manpages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install prerequisites
+        run:  >-
+          sudo apt-get update
+
+          sudo apt-get install -y
+          ronn
+
+      - name: Generate manpages
+        run: make man


### PR DESCRIPTION
This workflow installs `ronn` prior to generating the manpages.