### PR TITLE
CI: perform test scripts linting

### DIFF
--- a/test/apt_add.bats
+++ b/test/apt_add.bats
@@ -7,83 +7,83 @@ setup() {
 }
 
 @test "freight-add adds package to distro main component" {
-    run freight_add ${FIXTURES}/test_1.0_all.deb apt/example
+    run freight_add "${FIXTURES}"/test_1.0_all.deb apt/example
     assert_success
     assert_output "# [freight] added ${FIXTURES}/test_1.0_all.deb to apt/example"
-    test -e ${FREIGHT_LIB}/apt/example/test_1.0_all.deb
+    test -e "${FREIGHT_LIB}"/apt/example/test_1.0_all.deb
 }
 
 @test "freight-add adds package to a component" {
-    freight_add ${FIXTURES}/test_1.0_all.deb apt/example/comp
-    test -e ${FREIGHT_LIB}/apt/example/comp/test_1.0_all.deb
+    freight_add "${FIXTURES}"/test_1.0_all.deb apt/example/comp
+    test -e "${FREIGHT_LIB}"/apt/example/comp/test_1.0_all.deb
 }
 
 @test "freight-add adds package and hard link to multiple components" {
-    freight_add ${FIXTURES}/test_1.0_all.deb apt/example/comp apt/example/another
-    test -e ${FREIGHT_LIB}/apt/example/comp/test_1.0_all.deb
-    test -e ${FREIGHT_LIB}/apt/example/another/test_1.0_all.deb
-    test $(stat -c '%i' ${FREIGHT_LIB}/apt/example/comp/*.deb) -eq $(stat -c '%i' ${FREIGHT_LIB}/apt/example/another/*.deb)
+    freight_add "${FIXTURES}"/test_1.0_all.deb apt/example/comp apt/example/another
+    test -e "${FREIGHT_LIB}"/apt/example/comp/test_1.0_all.deb
+    test -e "${FREIGHT_LIB}"/apt/example/another/test_1.0_all.deb
+    test $(stat -c '%i' "${FREIGHT_LIB}"/apt/example/comp/*.deb) -eq $(stat -c '%i' "${FREIGHT_LIB}"/apt/example/another/*.deb)
 }
 
 @test "freight-add detects duplicate package" {
-    freight_add ${FIXTURES}/test_1.0_all.deb apt/example
-    run freight_add ${FIXTURES}/test_1.0_all.deb apt/example
+    freight_add "${FIXTURES}"/test_1.0_all.deb apt/example
+    run freight_add "${FIXTURES}"/test_1.0_all.deb apt/example
     assert_success
     assert_output "# [freight] apt/example already has ${FIXTURES}/test_1.0_all.deb"
 }
 
 @test "freight-add adds source .dsc files" {
-    run freight_add ${FIXTURES}/source_1.0-1.dsc apt/example
+    run freight_add "${FIXTURES}"/source_1.0-1.dsc apt/example
     assert_success
     assert_output "# [freight] added ${FIXTURES}/source_1.0-1.dsc to apt/example"
-    test -e ${FREIGHT_LIB}/apt/example/source_1.0-1.dsc
+    test -e "${FREIGHT_LIB}"/apt/example/source_1.0-1.dsc
 }
 
 @test "freight-add adds source .tar.gz files" {
-    run freight_add ${FIXTURES}/source_1.0-1.tar.gz apt/example
+    run freight_add "${FIXTURES}"/source_1.0-1.tar.gz apt/example
     assert_success
     assert_output "# [freight] added ${FIXTURES}/source_1.0-1.tar.gz to apt/example"
-    test -e ${FREIGHT_LIB}/apt/example/source_1.0-1.tar.gz
+    test -e "${FREIGHT_LIB}"/apt/example/source_1.0-1.tar.gz
 }
 
 @test "freight-add adds source .tar.bz2 files" {
-    run freight_add ${FIXTURES}/source_1.0-1.tar.bz2 apt/example
+    run freight_add "${FIXTURES}"/source_1.0-1.tar.bz2 apt/example
     assert_success
     assert_output "# [freight] added ${FIXTURES}/source_1.0-1.tar.bz2 to apt/example"
-    test -e ${FREIGHT_LIB}/apt/example/source_1.0-1.tar.bz2
+    test -e "${FREIGHT_LIB}"/apt/example/source_1.0-1.tar.bz2
 }
 
 @test "freight-add adds source .tar.xz files" {
-    run freight_add ${FIXTURES}/source_1.0-1.tar.xz apt/example
+    run freight_add "${FIXTURES}"/source_1.0-1.tar.xz apt/example
     assert_success
     assert_output "# [freight] added ${FIXTURES}/source_1.0-1.tar.xz to apt/example"
-    test -e ${FREIGHT_LIB}/apt/example/source_1.0-1.tar.xz
+    test -e "${FREIGHT_LIB}"/apt/example/source_1.0-1.tar.xz
 }
 
 @test "freight-add adds source .tar.lzma files" {
-    run freight_add ${FIXTURES}/source_1.0-1.tar.lzma apt/example
+    run freight_add "${FIXTURES}"/source_1.0-1.tar.lzma apt/example
     assert_success
     assert_output "# [freight] added ${FIXTURES}/source_1.0-1.tar.lzma to apt/example"
-    test -e ${FREIGHT_LIB}/apt/example/source_1.0-1.tar.lzma
+    test -e "${FREIGHT_LIB}"/apt/example/source_1.0-1.tar.lzma
 }
 
 @test "freight-add adds source .orig.tar.gz files" {
-    run freight_add ${FIXTURES}/source_1.0.orig.tar.gz apt/example
+    run freight_add "${FIXTURES}"/source_1.0.orig.tar.gz apt/example
     assert_success
     assert_output "# [freight] added ${FIXTURES}/source_1.0.orig.tar.gz to apt/example"
-    test -e ${FREIGHT_LIB}/apt/example/source_1.0.orig.tar.gz
+    test -e "${FREIGHT_LIB}"/apt/example/source_1.0.orig.tar.gz
 }
 
 @test "freight-add adds source .git files" {
-    run freight_add ${FIXTURES}/source-git_1.0-1.git apt/example
+    run freight_add "${FIXTURES}"/source-git_1.0-1.git apt/example
     assert_success
     assert_output "# [freight] added ${FIXTURES}/source-git_1.0-1.git to apt/example"
-    test -e ${FREIGHT_LIB}/apt/example/source-git_1.0-1.git
+    test -e "${FREIGHT_LIB}"/apt/example/source-git_1.0-1.git
 }
 
 @test "freight-add handles VARLIB being a symlink" {
-    mv $FREIGHT_LIB ${FREIGHT_LIB}_real
-    ln -s ${FREIGHT_LIB}_real $FREIGHT_LIB
-    freight_add ${FIXTURES}/test_1.0_all.deb apt/example/comp
-    test -e ${FREIGHT_LIB}_real/apt/example/comp/test_1.0_all.deb
+    mv "$FREIGHT_LIB" "${FREIGHT_LIB}"_real
+    ln -s "${FREIGHT_LIB}"_real "$FREIGHT_LIB"
+    freight_add "${FIXTURES}"/test_1.0_all.deb apt/example/comp
+    test -e "${FREIGHT_LIB}"_real/apt/example/comp/test_1.0_all.deb
 }

--- a/test/apt_cache.bats
+++ b/test/apt_cache.bats
@@ -5,46 +5,46 @@ load apt_helpers
 
 setup() {
     freight_init
-    freight_add ${FIXTURES}/test_1.0_all.deb apt/example
-    freight_add ${FIXTURES}/test_1.0_all.deb apt/example/comp
+    freight_add "${FIXTURES}"/test_1.0_all.deb apt/example
+    freight_add "${FIXTURES}"/test_1.0_all.deb apt/example/comp
     configure_local_apt
 }
 
 @test "freight-cache builds distro Release/InRelease file" {
     freight_cache -v
-    test -e ${FREIGHT_CACHE}/dists/example/Release
-    egrep "^Components: comp main" ${FREIGHT_CACHE}/dists/example/Release
-    test -e ${FREIGHT_CACHE}/dists/example/InRelease
-    egrep "^Components: comp main" ${FREIGHT_CACHE}/dists/example/InRelease
+    test -e "${FREIGHT_CACHE}"/dists/example/Release
+    grep -E "^Components: comp main" "${FREIGHT_CACHE}"/dists/example/Release
+    test -e "${FREIGHT_CACHE}"/dists/example/InRelease
+    grep -E "^Components: comp main" "${FREIGHT_CACHE}"/dists/example/InRelease
 }
 
 @test "freight-cache builds per-component Release file" {
     freight_cache -v
-    test -e ${FREIGHT_CACHE}/dists/example/comp/binary-amd64/Release
-    test -e ${FREIGHT_CACHE}/dists/example/main/binary-amd64/Release
+    test -e "${FREIGHT_CACHE}"/dists/example/comp/binary-amd64/Release
+    test -e "${FREIGHT_CACHE}"/dists/example/main/binary-amd64/Release
 }
 
 @test "freight-cache builds pool" {
     freight_cache -v
-    test -e ${FREIGHT_CACHE}/pool/example/comp/t/test/test_1.0_all.deb
-    test -e ${FREIGHT_CACHE}/pool/example/main/t/test/test_1.0_all.deb
+    test -e "${FREIGHT_CACHE}"/pool/example/comp/t/test/test_1.0_all.deb
+    test -e "${FREIGHT_CACHE}"/pool/example/main/t/test/test_1.0_all.deb
 }
 
 @test "freight-cache generates valid Release/InRelease signatures" {
     freight_cache -v
-    gpg --verify ${FREIGHT_CACHE}/dists/example/Release.gpg ${FREIGHT_CACHE}/dists/example/Release
-    gpg --verify ${FREIGHT_CACHE}/dists/example/InRelease
+    gpg --verify "${FREIGHT_CACHE}"/dists/example/Release.gpg "${FREIGHT_CACHE}"/dists/example/Release
+    gpg --verify "${FREIGHT_CACHE}"/dists/example/InRelease
 }
 
 @test "freight-cache signs Release/InRelease with two keys" {
-    sed -i 's/^GPG=.*/GPG="freight@example.com freight2@example.com"/' $FREIGHT_CONFIG
+    sed -i 's/^GPG=.*/GPG="freight@example.com freight2@example.com"/' "$FREIGHT_CONFIG"
     freight_cache -v
 
-    gpg --status-fd 1 --verify ${FREIGHT_CACHE}/dists/example/Release.gpg ${FREIGHT_CACHE}/dists/example/Release >/tmp/verify.out
+    gpg --status-fd 1 --verify "${FREIGHT_CACHE}"/dists/example/Release.gpg "${FREIGHT_CACHE}"/dists/example/Release >/tmp/verify.out
     run grep -c GOODSIG /tmp/verify.out
     assert_output "2"
 
-    gpg --status-fd 1 --verify ${FREIGHT_CACHE}/dists/example/InRelease >/tmp/verify.out
+    gpg --status-fd 1 --verify "${FREIGHT_CACHE}"/dists/example/InRelease >/tmp/verify.out
     run grep -c GOODSIG /tmp/verify.out
     assert_output "2"
 }
@@ -57,37 +57,37 @@ setup() {
 @test "apt-get fetches package list" {
     check_apt_support
     freight_cache -v
-    echo "deb file://${FREIGHT_CACHE} example main" > ${TMPDIR}/apt/etc/apt/sources.list
-    apt-get -c ${FIXTURES}/apt.conf update
-    apt-cache -c ${FIXTURES}/apt.conf show test
+    echo "deb file://${FREIGHT_CACHE} example main" > "${TMPDIR}"/apt/etc/apt/sources.list
+    apt-get -c "${FIXTURES}"/apt.conf update
+    apt-cache -c "${FIXTURES}"/apt.conf show test
 }
 
 @test "freight-cache removes deleted packages from pool" {
     freight_cache -v
-    test -e ${FREIGHT_CACHE}/pool/example/main/t/test/test_1.0_all.deb
-    rm -f ${FREIGHT_LIB}/apt/example/test_1.0_all.deb
+    test -e "${FREIGHT_CACHE}"/pool/example/main/t/test/test_1.0_all.deb
+    rm -f "${FREIGHT_LIB}"/apt/example/test_1.0_all.deb
 
     run freight_cache -v
     assert_success
     assert_output ""
-    test ! -e ${FREIGHT_CACHE}/pool/example/main/t/test/test_1.0_all.deb
+    test ! -e "${FREIGHT_CACHE}"/pool/example/main/t/test/test_1.0_all.deb
 }
 
 @test "freight-cache --keep retains deleted packages in pool" {
     freight_cache -v
-    test -e ${FREIGHT_CACHE}/pool/example/main/t/test/test_1.0_all.deb
-    rm -f ${FREIGHT_LIB}/apt/example/test_1.0_all.deb
+    test -e "${FREIGHT_CACHE}"/pool/example/main/t/test/test_1.0_all.deb
+    rm -f "${FREIGHT_LIB}"/apt/example/test_1.0_all.deb
 
     run freight_cache -v --keep
     assert_success
     assert_output ""
-    test -e ${FREIGHT_CACHE}/pool/example/main/t/test/test_1.0_all.deb
+    test -e "${FREIGHT_CACHE}"/pool/example/main/t/test/test_1.0_all.deb
 }
 
 @test "freight-cache handles VARLIB being a symlink" {
-    mv $FREIGHT_LIB ${FREIGHT_LIB}_real
-    ln -s ${FREIGHT_LIB}_real $FREIGHT_LIB
+    mv "$FREIGHT_LIB" "${FREIGHT_LIB}"_real
+    ln -s "${FREIGHT_LIB}"_real "$FREIGHT_LIB"
     freight_cache
-    test -e ${FREIGHT_CACHE}/pool/example/comp/t/test/test_1.0_all.deb
-    test -e ${FREIGHT_CACHE}/pool/example/main/t/test/test_1.0_all.deb
+    test -e "${FREIGHT_CACHE}"/pool/example/comp/t/test/test_1.0_all.deb
+    test -e "${FREIGHT_CACHE}"/pool/example/main/t/test/test_1.0_all.deb
 }

--- a/test/apt_cache_source.bats
+++ b/test/apt_cache_source.bats
@@ -9,42 +9,42 @@ setup() {
 }
 
 @test "freight-cache skips partial source packages" {
-    freight_add ${FIXTURES}/source_1.0-1.dsc apt/example
+    freight_add "${FIXTURES}"/source_1.0-1.dsc apt/example
     run freight_cache
     assert_success
     assert_output "# [freight] skipping invalid Debian source package source_1.0-1.dsc"
 }
 
 @test "freight-cache builds source-only archive" {
-    freight_add ${FIXTURES}/source_1.0-1.dsc apt/example
-    freight_add ${FIXTURES}/source_1.0-1.tar.gz apt/example
-    freight_add ${FIXTURES}/source_1.0.orig.tar.gz apt/example
+    freight_add "${FIXTURES}"/source_1.0-1.dsc apt/example
+    freight_add "${FIXTURES}"/source_1.0-1.tar.gz apt/example
+    freight_add "${FIXTURES}"/source_1.0.orig.tar.gz apt/example
     run freight_cache
     assert_success
     echo -e "# [freight] adding source_1.0-1.dsc to pool\n# [freight] adding source_1.0.orig.tar.gz to pool\n# [freight] adding source_1.0-1.tar.gz to pool" | assert_output
-    test -e ${FREIGHT_CACHE}/pool/example/main/s/source/source_1.0-1.dsc
-    test -e ${FREIGHT_CACHE}/pool/example/main/s/source/source_1.0-1.tar.gz
-    test -e ${FREIGHT_CACHE}/pool/example/main/s/source/source_1.0.orig.tar.gz
+    test -e "${FREIGHT_CACHE}"/pool/example/main/s/source/source_1.0-1.dsc
+    test -e "${FREIGHT_CACHE}"/pool/example/main/s/source/source_1.0-1.tar.gz
+    test -e "${FREIGHT_CACHE}"/pool/example/main/s/source/source_1.0.orig.tar.gz
 }
 
 @test "freight-cache builds source-only archive for git format" {
-    freight_add ${FIXTURES}/source-git_1.0-1.dsc apt/example
-    freight_add ${FIXTURES}/source-git_1.0-1.git apt/example
+    freight_add "${FIXTURES}"/source-git_1.0-1.dsc apt/example
+    freight_add "${FIXTURES}"/source-git_1.0-1.git apt/example
     run freight_cache
     assert_success
     echo -e "# [freight] adding source-git_1.0-1.dsc to pool\n# [freight] adding source-git_1.0-1.git to pool" | assert_output
-    test -e ${FREIGHT_CACHE}/pool/example/main/s/source-git/source-git_1.0-1.dsc
-    test -e ${FREIGHT_CACHE}/pool/example/main/s/source-git/source-git_1.0-1.git
+    test -e "${FREIGHT_CACHE}"/pool/example/main/s/source-git/source-git_1.0-1.dsc
+    test -e "${FREIGHT_CACHE}"/pool/example/main/s/source-git/source-git_1.0-1.git
 }
 
 @test "apt-get fetches source package list" {
     check_apt_support
-    freight_add ${FIXTURES}/source_1.0-1.dsc apt/example
-    freight_add ${FIXTURES}/source_1.0-1.tar.gz apt/example
-    freight_add ${FIXTURES}/source_1.0.orig.tar.gz apt/example
+    freight_add "${FIXTURES}"/source_1.0-1.dsc apt/example
+    freight_add "${FIXTURES}"/source_1.0-1.tar.gz apt/example
+    freight_add "${FIXTURES}"/source_1.0.orig.tar.gz apt/example
     freight_cache
 
-    echo "deb-src file://${FREIGHT_CACHE} example main" > ${TMPDIR}/apt/etc/apt/sources.list
-    apt-get -c ${FIXTURES}/apt.conf update
-    apt-cache -c ${FIXTURES}/apt.conf showsrc source | grep "Package: source"
+    echo "deb-src file://${FREIGHT_CACHE} example main" > "${TMPDIR}"/apt/etc/apt/sources.list
+    apt-get -c "${FIXTURES}"/apt.conf update
+    apt-cache -c "${FIXTURES}"/apt.conf showsrc source | grep "Package: source"
 }

--- a/test/apt_helpers.bash
+++ b/test/apt_helpers.bash
@@ -1,13 +1,13 @@
 # vim: et:ts=4:sw=4:ft=sh
 
 configure_local_apt() {
-    mkdir -p ${TMPDIR}/apt/etc/apt
-    mkdir -p ${TMPDIR}/apt/var/lib/apt
-    mkdir -p ${TMPDIR}/apt/var/lib/dpkg
-    mkdir -p ${TMPDIR}/apt/var/cache/apt
+    mkdir -p "$TMPDIR"/apt/etc/apt
+    mkdir -p "$TMPDIR"/apt/var/lib/apt
+    mkdir -p "$TMPDIR"/apt/var/lib/dpkg
+    mkdir -p "$TMPDIR"/apt/var/cache/apt
 
-    if [ ! -e "${TMPDIR}"/apt/var/lib/dpkg/status ]; then
-        touch "${TMPDIR}"/apt/var/lib/dpkg/status
+    if [ ! -e "$TMPDIR"/apt/var/lib/dpkg/status ]; then
+        touch "$TMPDIR"/apt/var/lib/dpkg/status
     fi
     if [ ! -e "$TMPDIR"/apt/etc/apt/trusted.gpg ]; then
         gpg --output "$TMPDIR"/apt/etc/apt/trusted.gpg --export freight@example.com
@@ -16,5 +16,5 @@ configure_local_apt() {
 
 check_apt_support() {
     type apt-get || skip "missing apt-get"
-    apt-get --version | grep Ver:.*deb || skip "missing apt-get deb support"
+    apt-get --version | grep "Ver:.*deb" || skip "missing apt-get deb support"
 }

--- a/test/freight_helpers.bash
+++ b/test/freight_helpers.bash
@@ -4,7 +4,7 @@ TOPDIR=$PWD
 FIXTURES=${TOPDIR}/test/fixtures
 TMPDIR=${TOPDIR}/test/tmp
 
-load ${TMPDIR}/bats-assert/all.bash
+load "${TMPDIR}"/bats-assert/all.bash
 
 FREIGHT_HOME=${TMPDIR}/freight
 FREIGHT_CONFIG=${FREIGHT_HOME}/etc/freight.conf
@@ -15,34 +15,34 @@ export GNUPGHOME=${TMPDIR}/gpg
 
 freight_init() {
     gpg_init
-    rm -rf $FREIGHT_HOME
-    mkdir -p $FREIGHT_CACHE $FREIGHT_LIB
+    rm -rf "$FREIGHT_HOME"
+    mkdir -p "$FREIGHT_CACHE" "$FREIGHT_LIB"
     bin/freight init \
         -g freight@example.com \
-        -c $FREIGHT_CONFIG \
-        --libdir $FREIGHT_LIB \
-        --cachedir $FREIGHT_CACHE \
+        -c "$FREIGHT_CONFIG" \
+        --libdir "$FREIGHT_LIB" \
+        --cachedir "$FREIGHT_CACHE" \
         --archs "i386 amd64" \
         "$@"
 }
 
 freight_add() {
-    bin/freight add -c $FREIGHT_CONFIG "$@"
+    bin/freight add -c "$FREIGHT_CONFIG" "$@"
 }
 
 freight_cache() {
-    bin/freight cache -p "$FIXTURES"/passphrase -c $FREIGHT_CONFIG "$@"
+    bin/freight cache -p "$FIXTURES"/passphrase -c "$FREIGHT_CONFIG" "$@"
 }
 
 freight_cache_nohup() {
-    nohup bin/freight cache  -p "$FIXTURES"/passphrase -c $FREIGHT_CONFIG "$@"
+    nohup bin/freight cache  -p "$FIXTURES"/passphrase -c "$FREIGHT_CONFIG" "$@"
 }
 
 # Generates a GPG key for all tests, once only due to entropy required
 gpg_init() {
-    if [ ! -e $GNUPGHOME ]; then
-        mkdir -p $GNUPGHOME
-        chmod 0700 $GNUPGHOME
+    if [ ! -e "$GNUPGHOME" ]; then
+        mkdir -p "$GNUPGHOME"
+        chmod 0700 "$GNUPGHOME"
         gpg --batch --yes --passphrase-fd 0 --import "$FIXTURES"/first_key.gpg < "$FIXTURES"/passphrase
         gpg --batch --yes --passphrase-fd 0 --import "$FIXTURES"/second_key.gpg < "$FIXTURES"/passphrase
     fi


### PR DESCRIPTION
Add double quotes and replace the deprecated "egrep" with "grep -E".