### PR TITLE
CI: fix trusted key usage

### DIFF
--- a/test/apt_cache.bats
+++ b/test/apt_cache.bats
@@ -57,7 +57,7 @@ setup() {
 @test "apt-get fetches package list" {
     check_apt_support
     freight_cache -v
-    echo "deb file://${FREIGHT_CACHE} example main" > "${TMPDIR}"/apt/etc/apt/sources.list
+    echo "deb [signed-by=${TMPDIR}/apt/etc/apt/trusted.gpg] file://${FREIGHT_CACHE} example main" > "${TMPDIR}"/apt/etc/apt/sources.list
     apt-get -c "${FIXTURES}"/apt.conf update
     apt-cache -c "${FIXTURES}"/apt.conf show test
 }

--- a/test/apt_cache_source.bats
+++ b/test/apt_cache_source.bats
@@ -44,7 +44,7 @@ setup() {
     freight_add "${FIXTURES}"/source_1.0.orig.tar.gz apt/example
     freight_cache
 
-    echo "deb-src file://${FREIGHT_CACHE} example main" > "${TMPDIR}"/apt/etc/apt/sources.list
+    echo "deb-src [signed-by=${TMPDIR}/apt/etc/apt/trusted.gpg] file://${FREIGHT_CACHE} example main" > "${TMPDIR}"/apt/etc/apt/sources.list
     apt-get -c "${FIXTURES}"/apt.conf update
     apt-cache -c "${FIXTURES}"/apt.conf showsrc source | grep "Package: source"
 }


### PR DESCRIPTION
Use "signed-by" key in the `sources.list` definition instead of the deprecated method with the default trusted keys.