### PR TITLE
bin/freight-cache: don't quote the FIND_L variable

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -118,7 +118,8 @@ for DIR in $DIRS; do
     # whatever it wants.
     . "$LIB/$MANAGER.sh"
     SORT="$(sort -V <"/dev/null" 2>"/dev/null" && echo "sort -V" || echo "sort")"
-    find "$FIND_L" "$DIR" -type "f" -printf "%P\n" 2>"/dev/null" |
+    # shellcheck disable=SC2086
+    find $FIND_L "$DIR" -type "f" -printf "%P\n" 2>"/dev/null" |
         eval "$SORT" |
         eval "${MANAGER}_cache" "$DIST"
 


### PR DESCRIPTION
`FIND_L` variable defines the -L parameter to the `find` command. Hence it should not be quoted. Otherwise, `find` command produces the following error:

`find: ‘’: No such file or directory`

Fixes #138 